### PR TITLE
change filter type name

### DIFF
--- a/app/models/invoices.ts
+++ b/app/models/invoices.ts
@@ -13,14 +13,14 @@ type InvoicesTable = {
   status: "pending" | "paid";
 };
 
-type FilteredFetch = {
+type FetchFilter = {
   query: string;
   currentPage: number;
 };
 
 export function Invoices(prismaInvoice: PrismaClient["invoices"]) {
   return Object.assign(prismaInvoice, {
-    async filteredFetch(data: FilteredFetch): Promise<InvoicesTable[]> {
+    async filteredFetch(data: FetchFilter): Promise<InvoicesTable[]> {
       const prisma = new PrismaClient();
       const offset = (data.currentPage - 1) * ITEMS_PER_PAGE;
 
@@ -47,9 +47,7 @@ export function Invoices(prismaInvoice: PrismaClient["invoices"]) {
 
       return invoices;
     },
-    async fetchTotaltPages(
-      data: Pick<FilteredFetch, "query">
-    ): Promise<number> {
+    async fetchTotaltPages(data: Pick<FetchFilter, "query">): Promise<number> {
       const prisma = new PrismaClient();
 
       // NOTE: 生クエリのcount()はbigintを返却するのでintegerにキャスト


### PR DESCRIPTION
This pull request includes changes to the `app/models/invoices.ts` file to rename a type and update its usage across the file. The most important changes include renaming the `FilteredFetch` type to `FetchFilter` and updating related function parameters.

Changes to type names and function parameters:

* [`app/models/invoices.ts`](diffhunk://#diff-b5478ec626ffc35f7a2a7c14ced4a37ab2d951a852fbe6b496c80237ea03a09dL16-R23): Renamed the `FilteredFetch` type to `FetchFilter` and updated the `filteredFetch` function parameter to use the new type name.
* [`app/models/invoices.ts`](diffhunk://#diff-b5478ec626ffc35f7a2a7c14ced4a37ab2d951a852fbe6b496c80237ea03a09dL50-R50): Updated the `fetchTotaltPages` function parameter to use the new `FetchFilter` type name.