### PR TITLE
move toaster into notify

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import "@/app/ui/global.css";
 import { inter } from "@/app/ui/fonts";
-import { Toaster } from "@/components/ui/sonner";
 import { Notify } from "./ui/invoices/notify";
 import { cookies } from "next/headers";
 
@@ -16,7 +15,6 @@ export default async function RootLayout({
       <body className={`${inter.className} antialiased`}>
         {children}
         <Notify flash={flash?.value} />
-        <Toaster />
       </body>
     </html>
   );

--- a/app/ui/invoices/notify.tsx
+++ b/app/ui/invoices/notify.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { toast } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 
 export function Notify({ flash }: { flash: string | undefined }) {
   useEffect(() => {
@@ -14,5 +15,5 @@ export function Notify({ flash }: { flash: string | undefined }) {
       }
     }
   });
-  return null;
+  return <Toaster />;
 }


### PR DESCRIPTION
This pull request includes changes to the `app/layout.tsx` and `app/ui/invoices/notify.tsx` files to adjust the placement of the `Toaster` component. The `Toaster` component has been moved from the `RootLayout` to the `Notify` component.

Changes to `app/layout.tsx`:

* Removed the import of the `Toaster` component.
* Removed the `Toaster` component from the `RootLayout`'s body.

Changes to `app/ui/invoices/notify.tsx`:

* Added the import of the `Toaster` component.
* Added the `Toaster` component to the return statement of the `Notify` function.