### PR TITLE
fix(auth): github-auth-button errorCallbackURL を taimei-auth に向ける (PR14)

### DIFF
--- a/components/auth/github-auth-button.tsx
+++ b/components/auth/github-auth-button.tsx
@@ -17,8 +17,11 @@ export default function GithubAuthButton() {
     authClient.signIn.social({
       provider: "github",
       callbackURL: `${origin}${redirectPath}`,
-      // OAuth 失敗時は統合認証ページにリダイレクト（エラー表示 + 再試行導線）
-      errorCallbackURL: `${origin}/auth?error=signin_failed`,
+      // OAuth 失敗時は taimei-auth (Layer B) のエラー画面に遷移する。中間期間 (PR10a/b で
+      // taimei 側旧 auth UI 削除前) 用の暫定 hardcode。Better Auth は absolute URL を
+      // そのまま 302 先として使うため cross-origin (app → auth) 遷移可能。
+      errorCallbackURL:
+        "https://auth.taimei-code.com/auth/error?reason=signin_failed",
     });
   };
 


### PR DESCRIPTION
## やったこと

`components/auth/github-auth-button.tsx:21` の `errorCallbackURL` を旧 `${origin}/auth?error=signin_failed` (taimei 側) → `https://auth.taimei-code.com/auth/error?reason=signin_failed` (taimei-auth Layer B) に書換。

## なぜやるのか

phase1-auth-ui-migration.md 項目 24。GitHub OAuth 失敗時に taimei 側の旧認証画面に飛ぶ既存挙動を、PR3a で実装した Layer B の Error 画面 (`reason` クエリで文言切替) に向ける。中間期間 (PR10a/b で taimei 側旧 auth UI 削除前) 用の暫定対応で、PR10a/b 完了時に旧 `/auth` 画面ごと削除されるため自然に役目を終える。

## 設計判断

**hardcode で進める**: `NEXT_PUBLIC_AUTH_URL` env 化は PR5b で本格対応する予定 (after-signin / after-signup でも使うため)。PR14 は 1 行修正の暫定で、env 化を先取りすると scope が広がる。

## 動作確認結果

- `bunx tsc --noEmit`: PR14 関連の型エラー 0 件 (既存 Effect 型エラー 1 件は本 PR スコープ外)
- 動作確認は staging で OAuth 失敗 (callback で error 強制返却) → auth.taimei-code.com/auth/error 遷移確認

## CI マージ方針 (Phase 1 共通)

`unit-test.yml` の green 確認後マージ。Vercel preview / e2e は待たない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)