### PR TITLE
feat(auth): /auth/after-signin + /auth/after-signup + NEXT_PUBLIC_AUTH_URL env 化 (PR5b)

### DIFF
--- a/app/auth/after-signin/page.tsx
+++ b/app/auth/after-signin/page.tsx
@@ -1,0 +1,37 @@
+import { redirect } from "next/navigation";
+import { Effect, Either } from "effect";
+
+import { getSession } from "@/app/lib/auth-guard";
+import { runService, UserProfileService } from "@/app/services";
+
+// Better Auth のログイン後着地点 (sign 流)。Layer B から callbackURL=https://app.taimei-code.com/auth/after-signin に飛んでくる。
+//
+// 分岐:
+// (1) 未認証 (session なし) → Layer B の error 画面に誘導 (signin_failed)
+// (2) profile が DB に存在しない (初回ログイン) → /setting/profile で補完誘導
+// (3) profile 既存 → /dashboard
+//
+// (2) の判定: UserProfileService.findByUserId が UserProfileNotFound を返す or null/undefined を返した場合。
+// Effect 結果を Either で受け取り、Left (NotFound) or Right が空なら未補完と判断。
+const AUTH_URL =
+  process.env.NEXT_PUBLIC_AUTH_URL ?? "https://auth.taimei-code.com";
+
+export default async function AfterSignInPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect(`${AUTH_URL}/auth/error?reason=signin_failed`);
+  }
+
+  const result = await runService(() =>
+    Effect.gen(function* () {
+      const service = yield* UserProfileService;
+      return yield* service.findByUserId(session.user.id);
+    }),
+  );
+
+  if (Either.isLeft(result) || result.right == null) {
+    redirect("/setting/profile");
+  }
+
+  redirect("/dashboard");
+}

--- a/app/auth/after-signup/page.tsx
+++ b/app/auth/after-signup/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+
+import { getSession } from "@/app/lib/auth-guard";
+
+// Better Auth のサインアップ後着地点 (sign 流)。Layer B SignUp から callbackURL=https://app.taimei-code.com/auth/after-signup に飛んでくる。
+//
+// 分岐:
+// (1) 未認証 → Layer B の error 画面に誘導
+// (2) createdAt が 5 分以上前 → 既存ユーザーが /auth/signup に来た = 二重サインアップ → Layer B の error 画面 (signup_already_completed)
+// (3) 新規ユーザー → /setting/profile?welcome=1 で profile 補完を促す (welcome 表示は profile 画面側に統合)
+//
+// 5 分の根拠: Better Auth Magic Link の expiresIn=300 と一致 — Magic Link クリック後 5 分以内なら新規。
+// 5 分以上前は既にセッション確立済 (= 既存ユーザー) と判断する。
+const AUTH_URL =
+  process.env.NEXT_PUBLIC_AUTH_URL ?? "https://auth.taimei-code.com";
+const NEW_USER_WINDOW_MS = 5 * 60 * 1000;
+
+export default async function AfterSignUpPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect(`${AUTH_URL}/auth/error?reason=signin_failed`);
+  }
+
+  const createdAt = new Date(session.user.createdAt);
+  const isWithinNewUserWindow =
+    Date.now() - createdAt.getTime() < NEW_USER_WINDOW_MS;
+
+  if (!isWithinNewUserWindow) {
+    redirect(`${AUTH_URL}/auth/error?reason=signup_already_completed`);
+  }
+
+  redirect("/setting/profile?welcome=1");
+}

--- a/components/auth/github-auth-button.tsx
+++ b/components/auth/github-auth-button.tsx
@@ -18,10 +18,9 @@ export default function GithubAuthButton() {
       provider: "github",
       callbackURL: `${origin}${redirectPath}`,
       // OAuth 失敗時は taimei-auth (Layer B) のエラー画面に遷移する。中間期間 (PR10a/b で
-      // taimei 側旧 auth UI 削除前) 用の暫定 hardcode。Better Auth は absolute URL を
-      // そのまま 302 先として使うため cross-origin (app → auth) 遷移可能。
-      errorCallbackURL:
-        "https://auth.taimei-code.com/auth/error?reason=signin_failed",
+      // taimei 側旧 auth UI 削除前) 用の暫定。Better Auth は absolute URL をそのまま 302 先と
+      // して使うため cross-origin (app → auth) 遷移可能。env で env 切替可能 (PR5b で導入)。
+      errorCallbackURL: `${process.env.NEXT_PUBLIC_AUTH_URL ?? "https://auth.taimei-code.com"}/auth/error?reason=signin_failed`,
     });
   };
 


### PR DESCRIPTION
## やったこと

- `app/auth/after-signin/page.tsx`: Cookie 検証 + UserProfileService で profile 存在チェック → /setting/profile (補完誘導) or /dashboard
- `app/auth/after-signup/page.tsx`: Cookie 検証 + createdAt で二重サインアップ検出 (5 分閾値) → AUTH_URL/auth/error?reason=signup_already_completed or /setting/profile?welcome=1
- `components/auth/github-auth-button.tsx`: PR14 で hardcode した URL を `NEXT_PUBLIC_AUTH_URL` env 経由に置換

## なぜやるのか

phase1-auth-ui-migration.md 項目 15-16 の基盤D (taimei 側 dispatch) を実装。Layer B (taimei-auth `/auth/`) からのログイン / サインアップ完了時に taimei が受け取る着地点 2 ページ + env 化を一緒に実装。

PR10a/b で taimei 側旧 `/auth/page.tsx` を削除する前提のため、本 PR の着地点 2 ページは Layer B に移行後の **真の認証後フロー**となる。

## 設計判断

**5 分閾値 = Better Auth Magic Link `expiresIn=300` と整合**: Magic Link クリック後 5 分以内なら新規 (= signup フロー継続)、5 分以上前なら既にセッション確立済 (= 既存ユーザーが /auth/signup を再訪) と判断。閾値は Magic Link の上限と揃えることで「新規だがリンクが古い」エッジケースを排除。

**profile 補完誘導は `/setting/profile`**: 既存 user_profile Service / 設定画面が存在するため再利用。onboarding 画面は Phase 4 で別途構築 (plan の Out of Scope に既に記載済)。

**AUTH_URL の env 化**: PR14 で導入した hardcode を回避。dev (`http://localhost:3100`) / staging (`*.preview.taimei-code.com` 系) / production (`auth.taimei-code.com`) の切替を env で実現。

## ユーザー手動 (本 PR merge 前 or 直後)

`NEXT_PUBLIC_AUTH_URL` を env に追加 (3 環境):

```bash
# Vercel
# Settings → Environment Variables → New
# - Key: NEXT_PUBLIC_AUTH_URL
# - Value: https://auth.taimei-code.com
# - Environments: Production + Preview (Sensitive 不要、URL は public)

# .env.production (commit 不可、ローカル参照のみ)
NEXT_PUBLIC_AUTH_URL=https://auth.taimei-code.com

# .env.local (各自開発時)
NEXT_PUBLIC_AUTH_URL=http://localhost:3100
```

env 未設定でも default で `https://auth.taimei-code.com` を使うため動作するが、明示設定推奨。

## 動作確認結果

- `bunx tsc --noEmit`: PR5b 関連の型エラー 0 件
- `bun run test:db`: 全 80 件 pass (regression なし)
- 動作確認: staging で Layer B ログイン → /auth/after-signin → /dashboard or /setting/profile 遷移確認

## CI マージ方針 (Phase 1 共通)

`unit-test.yml` の green 確認後マージ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)