### PR TITLE
refactor(auth): proxy.ts を sign 流に書換 (PR7)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,29 +1,47 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSessionCookie } from "better-auth/cookies";
+import { buildAuthLoginUrl } from "@taimei-code/auth-client";
 
-// Better Auth 用のプロキシ（セッションCookieの存在チェックのみ）
+// sign 流: 未認証なら taimei-auth (Layer B) に redirect。helper (PR5a) で URL 構築を集約することで
+// クエリ名 typo / 順序ぶれを防ぐ。Cookie 検証は各ページで行うのは旧設計と同じ。
+//
+// publicPaths:
+// - "/" : LP / 未認証で見える top page
+// - "/api/auth": Better Auth callback (OAuth 戻り URL の処理経路)
+// - "/auth/after-signin", "/auth/after-signup": Layer B からの着地点 (Cookie 設定の race condition
+//   回避のため proxy をスキップ、各ページ側で getSession() で null チェック実装済)
+// 旧 "/auth" は publicPaths から削除 (PR10a で page.tsx ごと削除予定、それまでは Layer B に redirect)。
+const AUTH_URL =
+  process.env.NEXT_PUBLIC_AUTH_URL ?? "https://auth.taimei-code.com";
+
 export default async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // 認証不要なパス
-  const publicPaths = ["/", "/auth", "/api/auth"];
+  const publicPaths = [
+    "/",
+    "/api/auth",
+    "/auth/after-signin",
+    "/auth/after-signup",
+  ];
   const isPublicPath = publicPaths.some(
-    (path) => pathname === path || pathname.startsWith(path + "/")
+    (path) => pathname === path || pathname.startsWith(path + "/"),
   );
 
   if (isPublicPath) {
     return NextResponse.next();
   }
 
-  // セッションCookieの存在チェック（検証は各ページで行う）
   const sessionCookie = getSessionCookie(request, {
     cookiePrefix: "better-auth",
   });
 
   if (!sessionCookie) {
-    const authUrl = new URL("/auth", request.url);
-    authUrl.searchParams.set("callbackUrl", request.url);
-    return NextResponse.redirect(authUrl);
+    const url = buildAuthLoginUrl({
+      authBaseUrl: AUTH_URL,
+      service: "taimei",
+      returnTo: request.url,
+    });
+    return NextResponse.redirect(url);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## やったこと

- `proxy.ts`: 未認証時の redirect 先を旧 `/auth?callbackUrl=` → Layer B (`auth.taimei-code.com/auth/?service_name=taimei&redirect_url=`) に変更
- URL 構築は `buildAuthLoginUrl` helper (PR5a で導入) に集約
- publicPaths から `/auth` を削除、`/auth/after-signin` `/auth/after-signup` を追加

## なぜやるのか

phase1-auth-ui-migration.md 項目 14 (基盤D)。sign 流 (URL 構築をプロダクト側で行う) の core 実装。Layer B (PR2-3 で確立) と taimei 側着地点 (PR5b) を proxy で接続する PR。

## 設計判断

**`buildAuthLoginUrl` helper 活用**: PR5a で実装した URL 構築 helper を proxy で利用することで、SignInParams (PR1 Zod schema) のクエリ名と型レベル整合。手書き URL だと `redirect_url` vs `redirectUrl` 等の typo リスクがある。

**publicPaths から `/auth` を削除**: 旧 page.tsx (`app/auth/page.tsx`) は PR10a で削除予定。中間期間で `/auth` への直接アクセスは Layer B に redirect される (= 正しい挙動)。

**after-signin/after-signup を publicPaths に追加**: Layer B redirect → browser cookie 受信の race condition を回避。各ページ内で `getSession()` で null チェック済 (PR5b 実装) のため、proxy 経由の Cookie 検証は不要。

## 動作確認結果

- `bunx tsc --noEmit`: PR7 関連の型エラー 0 件
- `bun run test:db`: 全 80 件 pass (regression なし)
- 動作確認: staging で未認証アクセス → Layer B redirect → ログイン → /auth/after-signin → /dashboard 確認

## CI マージ方針 (Phase 1 共通)

`unit-test.yml` の green 確認後マージ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)