### PR TITLE
test(e2e): signIn helper + auth.spec を sign 流 URL に更新 (PR12b)

### DIFF
--- a/e2e/db/auth-client.ts
+++ b/e2e/db/auth-client.ts
@@ -1,0 +1,8 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import * as authSchema from "./auth-schema";
+
+// taimei-auth DB connection (e2e 環境では postgres://...:5435/auth)。
+// signIn helper の getVerificationToken / createTestUser がここを参照する。
+export const authDb = drizzle(process.env.AUTH_DATABASE_URL!, {
+  schema: authSchema,
+});

--- a/e2e/db/auth-schema.ts
+++ b/e2e/db/auth-schema.ts
@@ -1,0 +1,45 @@
+import {
+  pgTable,
+  text,
+  timestamp,
+  boolean,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+
+// taimei-auth (Layer B + Better Auth) DB の Better Auth schema (e2e helper 用、最小セット)。
+// signIn helper が verification token を取得するために必要な user / verification のみ定義。
+// session / account は signIn フローでの参照不要。
+export const user = pgTable(
+  "user",
+  {
+    id: text("id").primaryKey().notNull(),
+    name: text("name").notNull(),
+    email: text("email").notNull().unique(),
+    emailVerified: boolean("email_verified").default(false).notNull(),
+    image: text("image"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("user_email_key").using(
+      "btree",
+      table.email.asc().nullsLast().op("text_ops"),
+    ),
+  ],
+);
+
+export const verification = pgTable(
+  "verification",
+  {
+    id: text("id").primaryKey().notNull(),
+    identifier: text("identifier").notNull(),
+    value: text("value").notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("verification_identifier_idx").on(table.identifier),
+  ],
+);

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -20,8 +20,10 @@ export default defineConfig({
     ? [["html", { open: "never" }]]
     : [["html", { host: "0.0.0.0", port: "9323", open: "always" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */ use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.PLAYWRIGHT_BASE_URL,
+    /* Base URL to use in actions like `await page.goto('/')`.
+     * sign 流: APP_BASE_URL (taimei) を baseURL に固定。AUTH_BASE_URL (taimei-auth) は
+     * signIn helper / spec 内で個別に組み立てる (cross-origin のため). */
+    baseURL: process.env.APP_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,29 +1,35 @@
 import { test, expect } from "@playwright/test";
 import {
+  AUTH_BASE_URL,
   createTestUser,
   getVerificationToken,
   signInWithMagicLink,
   verifyMagicLinkAndGetContext,
 } from "./utils/signIn";
 
-test.describe("認証フロー", () => {
+// sign 流 (PR5b/PR7 で確立) の e2e。Layer B (taimei-auth) 経由ログインを検証する。
+// taimei への未認証アクセス → proxy が AUTH_BASE_URL/auth/?service_name=taimei&redirect_url=... に redirect。
+// Layer B の SignIn 画面でフォーム送信 → Magic Link verify → taimei /auth/after-signin → /dashboard。
+test.describe("認証フロー (sign 流)", () => {
   test.describe("保護ルートへの未認証アクセス", () => {
-    test("未認証で保護ルートにアクセスすると /auth?callbackUrl にリダイレクトされる", async ({
+    test("未認証で保護ルートにアクセスすると Layer B にリダイレクトされる", async ({
       page,
     }) => {
       await page.goto("/dashboard");
-      await expect(page).toHaveURL(/\/auth\?callbackUrl=.*dashboard/);
+      // proxy.ts が buildAuthLoginUrl で組んだ URL に redirect する想定
+      await expect(page).toHaveURL(
+        new RegExp(
+          `${AUTH_BASE_URL.replace(/\./g, "\\.")}/auth/\\?service_name=taimei&redirect_url=.*dashboard`,
+        ),
+      );
     });
 
-    test("ログイン後、callbackUrl にリダイレクトされる", async ({
+    test("ログイン後、redirect_url にリダイレクトされる", async ({
       page,
       browser,
     }) => {
       const testEmail = await createTestUser();
       await page.goto("/dashboard");
-      await expect(page).toHaveURL(/\/auth\?callbackUrl=.*dashboard/);
-
-      // Magic Link でのセッション作成後の挙動を検証
       const context = await signInWithMagicLink(browser, testEmail);
       const authedPage = await context.newPage();
       await authedPage.goto("/dashboard");
@@ -44,7 +50,6 @@ test.describe("認証フロー", () => {
     test("認証済みで / にアクセスしてもランディングページが表示される", async ({
       browser,
     }) => {
-      // 認証状態でもルートパスは /auth にリダイレクトしない仕様を検証
       const testEmail = await createTestUser();
       const context = await signInWithMagicLink(browser, testEmail);
       const page = await context.newPage();
@@ -56,31 +61,32 @@ test.describe("認証フロー", () => {
     });
   });
 
-  test.describe("統合認証フロー", () => {
+  test.describe("Layer B 経由の統合認証フロー", () => {
     test("未登録メールで認証すると新規アカウントが作成される", async ({
       page,
       browser,
     }) => {
-      // Arrange: 未登録メールアドレス
       const newEmail = `new-${Date.now()}@example.com`;
 
-      // Act: フォーム送信 → Magic Link 検証 → dashboard アクセス
-      await page.goto("/auth");
-      await page.getByLabel("Email").fill(newEmail);
-      await page.getByRole("button", { name: "メールで続ける" }).click();
+      // Layer B の SignIn 画面を直接訪問 (service_name=taimei + redirect_url=...)
+      const params = new URLSearchParams({
+        service_name: "taimei",
+        redirect_url: "http://app.taimei-code.local:3001/auth/after-signin",
+      });
+      await page.goto(`${AUTH_BASE_URL}/auth/?${params.toString()}`);
+      await page.getByLabel("メールアドレス").fill(newEmail);
+      await page
+        .getByRole("button", { name: "Magic Link を送信" })
+        .click();
 
-      await expect(
-        page
-          .locator("[data-sonner-toast]")
-          .filter({ hasText: "認証リンクをメールで送信しました。" })
-      ).toBeVisible();
+      // Magic Link 送信完了 (画面に「メールを送信しました」表示)
+      await expect(page.getByText(newEmail)).toBeVisible();
 
       const token = await getVerificationToken(newEmail);
       const context = await verifyMagicLinkAndGetContext(browser, token);
       const authedPage = await context.newPage();
       await authedPage.goto("/dashboard");
 
-      // Assert: ダッシュボードが表示される（認証成功）
       await expect(authedPage).toHaveURL(/\/dashboard/);
       await expect(authedPage.locator("h1")).toContainText("Dashboard");
 
@@ -88,62 +94,49 @@ test.describe("認証フロー", () => {
     });
 
     test("既存メールで認証するとログインできる", async ({ page, browser }) => {
-      // Arrange: 既存ユーザー作成
       const existingEmail = await createTestUser();
 
-      // Act: フォーム送信 → Magic Link 検証 → dashboard アクセス
-      await page.goto("/auth");
-      await page.getByLabel("Email").fill(existingEmail);
-      await page.getByRole("button", { name: "メールで続ける" }).click();
+      const params = new URLSearchParams({
+        service_name: "taimei",
+        redirect_url: "http://app.taimei-code.local:3001/auth/after-signin",
+      });
+      await page.goto(`${AUTH_BASE_URL}/auth/?${params.toString()}`);
+      await page.getByLabel("メールアドレス").fill(existingEmail);
+      await page
+        .getByRole("button", { name: "Magic Link を送信" })
+        .click();
 
-      await expect(
-        page
-          .locator("[data-sonner-toast]")
-          .filter({ hasText: "認証リンクをメールで送信しました。" })
-      ).toBeVisible();
+      await expect(page.getByText(existingEmail)).toBeVisible();
 
       const token = await getVerificationToken(existingEmail);
       const context = await verifyMagicLinkAndGetContext(browser, token);
       const authedPage = await context.newPage();
       await authedPage.goto("/dashboard");
 
-      // Assert: ダッシュボードが表示される（認証成功）
       await expect(authedPage).toHaveURL(/\/dashboard/);
       await expect(authedPage.locator("h1")).toContainText("Dashboard");
 
       await context.close();
     });
 
-    test("認証済みユーザーが /auth にアクセスすると /dashboard にリダイレクトされる", async ({
+    test("認証済みユーザーが /dashboard を直接訪問できる (proxy で redirect されない)", async ({
       browser,
     }) => {
-      // Arrange: 認証済みユーザー
       const testEmail = await createTestUser();
       const context = await signInWithMagicLink(browser, testEmail);
       const page = await context.newPage();
 
-      // Act: /auth にアクセス
-      await page.goto("/auth");
-
-      // Assert: /dashboard にリダイレクト
+      await page.goto("/dashboard");
       await expect(page).toHaveURL(/\/dashboard/);
 
       await context.close();
     });
 
-    test("/auth?error=signin_failed でフラッシュメッセージが表示される", async ({
+    test("Layer B のエラー画面 (signin_failed) が表示される", async ({
       page,
     }) => {
-      // Act: エラーパラメータ付きで /auth にアクセス
-      await page.goto("/auth?error=signin_failed");
-
-      // Assert: エラー toast + URL クリーン
-      await expect(
-        page
-          .locator("[data-sonner-toast]")
-          .filter({ hasText: "ログインに失敗しました。" })
-      ).toBeVisible();
-      await expect(page).toHaveURL("/auth");
+      await page.goto(`${AUTH_BASE_URL}/auth/error?reason=signin_failed`);
+      await expect(page.getByText("ログインに失敗しました")).toBeVisible();
     });
   });
 });

--- a/e2e/tests/utils/signIn.ts
+++ b/e2e/tests/utils/signIn.ts
@@ -1,14 +1,26 @@
 import { Browser, BrowserContext } from "@playwright/test";
-import { db } from "../../db/client";
-import { user, verification } from "../../db/schema";
 import { eq, desc } from "drizzle-orm";
 
-export const BASE_URL =
-  process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3001";
+import { authDb } from "../../db/auth-client";
+import { user, verification } from "../../db/auth-schema";
+
+// sign 流 (PR5b/PR7 で taimei に統合) 対応の e2e signIn helper。
+// taimei (app.taimei-code.local:3001) と taimei-auth (auth.taimei-code.local:3100) は別オリジン。
+// Magic Link 関連の API はすべて taimei-auth (AUTH_BASE_URL) に飛ばし、
+// 検証完了後 callbackURL = APP_BASE_URL/auth/after-signin に redirect させる。
+//
+// Cookie domain は AUTH_COOKIE_DOMAIN=taimei-code.local 設定済 (PR12a)。
+// Better Auth が Set-Cookie: Domain=.taimei-code.local で返すため、
+// Playwright BrowserContext に追加するときも同じ domain を指定する必要がある。
+export const APP_BASE_URL =
+  process.env.APP_BASE_URL ?? "http://app.taimei-code.local:3001";
+export const AUTH_BASE_URL =
+  process.env.AUTH_BASE_URL ?? "http://auth.taimei-code.local:3100";
+const COOKIE_DOMAIN = ".taimei-code.local";
 
 export async function createTestUser(): Promise<string> {
   const uuid = crypto.randomUUID();
-  await db.insert(user).values({
+  await authDb.insert(user).values({
     id: uuid,
     name: "E2E Test User",
     email: `e2e-${uuid}@example.com`,
@@ -17,19 +29,16 @@ export async function createTestUser(): Promise<string> {
   return `e2e-${uuid}@example.com`;
 }
 
-/**
- * Server Action の非同期処理完了を待つため、トークンが見つかるまでポーリング
- * デフォルト: 20回 × 1秒間隔 = 最大20秒
- */
+// Server Action の非同期処理完了を待つため、トークンが見つかるまでポーリング (最大 20s)。
 export async function getVerificationToken(
   email: string,
-  options: { maxRetries?: number; retryDelay?: number } = {}
+  options: { maxRetries?: number; retryDelay?: number } = {},
 ): Promise<string> {
   const { maxRetries = 20, retryDelay = 1000 } = options;
   const expectedValue = JSON.stringify({ email });
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
-    const record = await db
+    const record = await authDb
       .select()
       .from(verification)
       .where(eq(verification.value, expectedValue))
@@ -47,28 +56,27 @@ export async function getVerificationToken(
   }
 
   throw new Error(
-    `Verification token not found for ${email} after ${maxRetries} attempts`
+    `Verification token not found for ${email} after ${maxRetries} attempts`,
   );
 }
 
 export async function signInWithMagicLink(
   browser: Browser,
-  email: string
+  email: string,
 ): Promise<BrowserContext> {
-  const response = await fetch(`${BASE_URL}/api/auth/sign-in/magic-link`, {
+  // 1. taimei-auth に Magic Link 送信リクエスト (verification record が DB に書かれる)
+  const sendResp = await fetch(`${AUTH_BASE_URL}/api/auth/sign-in/magic-link`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email }),
   });
-
-  if (!response.ok) {
-    throw new Error(`Magic link request failed: ${response.status}`);
+  if (!sendResp.ok) {
+    throw new Error(`Magic link request failed: ${sendResp.status}`);
   }
 
+  // 2. DB から token を取得して verify。callbackURL は taimei /auth/after-signin (sign 流着地点)。
   const token = await getVerificationToken(email);
-
-  // Playwright の page.goto() ではなく fetch を使用（Set-Cookie ヘッダーを直接取得するため）
-  const verifyUrl = `${BASE_URL}/api/auth/magic-link/verify?token=${token}&callbackURL=/dashboard`;
+  const verifyUrl = `${AUTH_BASE_URL}/api/auth/magic-link/verify?token=${token}&callbackURL=${encodeURIComponent(`${APP_BASE_URL}/auth/after-signin`)}`;
   const verifyResponse = await fetch(verifyUrl, { redirect: "manual" });
 
   const setCookieHeader = verifyResponse.headers.get("set-cookie");
@@ -76,6 +84,7 @@ export async function signInWithMagicLink(
     throw new Error("No Set-Cookie header in verify response");
   }
 
+  // 3. Set-Cookie を BrowserContext に追加。domain は taimei-code.local (cross-subdomain)。
   const cookies = parseCookies(setCookieHeader);
   const context = await browser.newContext();
   await context.addCookies(cookies);
@@ -88,15 +97,12 @@ export async function signIn(browser: Browser): Promise<BrowserContext> {
   return signInWithMagicLink(browser, email);
 }
 
-/**
- * Magic Link トークンを検証してセッションを持つ BrowserContext を返す
- * signInWithMagicLink と異なり、トークンを直接受け取る（getVerificationToken 済みの場合に使用）
- */
+// 既知 token から直接 verify する (auth.spec.ts でフォーム送信後の token 取得経路で使用)。
 export async function verifyMagicLinkAndGetContext(
   browser: Browser,
-  token: string
+  token: string,
 ): Promise<BrowserContext> {
-  const verifyUrl = `${BASE_URL}/api/auth/magic-link/verify?token=${token}&callbackURL=/dashboard`;
+  const verifyUrl = `${AUTH_BASE_URL}/api/auth/magic-link/verify?token=${token}&callbackURL=${encodeURIComponent(`${APP_BASE_URL}/auth/after-signin`)}`;
   const verifyResponse = await fetch(verifyUrl, { redirect: "manual" });
 
   const setCookieHeader = verifyResponse.headers.get("set-cookie");
@@ -111,9 +117,7 @@ export async function verifyMagicLinkAndGetContext(
   return context;
 }
 
-export function parseCookies(
-  setCookieHeader: string
-): Array<{
+export function parseCookies(setCookieHeader: string): Array<{
   name: string;
   value: string;
   domain: string;
@@ -122,9 +126,7 @@ export function parseCookies(
   secure?: boolean;
   sameSite?: "Strict" | "Lax" | "None";
 }> {
-  // カンマ区切りだがクッキー値内にもカンマが含まれうるため、名前=値パターンの前でのみ分割
   const cookieStrings = setCookieHeader.split(/,(?=\s*[a-zA-Z_][a-zA-Z0-9_-]*=)/);
-  const domain = new URL(BASE_URL).hostname;
 
   return cookieStrings.map((cookieStr) => {
     const parts = cookieStr.split(";").map((p) => p.trim());
@@ -143,7 +145,7 @@ export function parseCookies(
     } = {
       name: name.trim(),
       value,
-      domain,
+      domain: COOKIE_DOMAIN,
       path: "/",
     };
 


### PR DESCRIPTION
## やったこと

- `e2e/db/auth-client.ts` + `e2e/db/auth-schema.ts`: taimei-auth DB (port 5435) 用の Drizzle client + Better Auth user/verification 最小 schema
- `e2e/tests/utils/signIn.ts`: APP_BASE_URL/AUTH_BASE_URL の二系統に分割、auth-db 経由 verification 取得、callbackURL を /auth/after-signin に固定、Cookie domain を `.taimei-code.local` 統一
- `e2e/playwright.config.ts`: baseURL に APP_BASE_URL を優先採用
- `e2e/tests/auth.spec.ts`: Layer B (taimei-auth `/auth/`) 経由の認証フローに書換

## なぜやるのか

phase1-auth-ui-migration.md 項目 38c-38e。PR12a で構築した e2e 環境で sign 流の認証往復 (Layer B → Magic Link verify → taimei `/auth/after-signin` → /dashboard) を Playwright で検証可能にする。後続 PR10a/b で安全に旧 UI 削除するための regression detection を確立。

## 設計判断

**signIn helper は Magic Link API 直接呼出**: helper は API ベースで session を素早く確立し、UI 操作は `auth.spec.ts` の主要シナリオ (未登録/既存メール) に集中。テスト実行時間短縮 + UI と API の役割分離。

**auth-db を分離**: 既存 `e2e/db/client.ts` (taimei) はそのまま、`e2e/db/auth-client.ts` を新設。物理的に分離した DB を e2e 層で明示。

**Cookie domain `.taimei-code.local` 統一**: PR12a で `AUTH_COOKIE_DOMAIN=taimei-code.local` 設定済 → cross-subdomain で app/auth に共有される Cookie を Playwright BrowserContext に正しく追加。

## 注

branch 名を `test/auth-e2e-signin-helper-update` → `chore/e2e-signin-helper-update` に変更 (remote の `refs/heads/test` フラット branch と namespace 競合のため)。

## 動作確認結果

- `bunx tsc --noEmit`: PR12b 関連の型エラー 0 件
- `bun run test:db`: 既存 80 件 全 pass
- e2e 実動作確認: staging で `docker compose -f docker-compose.e2e.yml up` で別途実施

## CI マージ方針 (Phase 1 共通)

`unit-test.yml` の green 確認後マージ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)