### PR TITLE
fix(e2e): signIn helper post-filter + auth-service migrate + CI default

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -72,6 +72,10 @@ services:
     build:
       context: '../taimei-auth'
       dockerfile: Dockerfile
+      args:
+        APP_ENV: test
+    command: >
+      sh -c "bunx drizzle-kit migrate && bun run src/index.ts"
     environment:
       - PORT=3100
       - DATABASE_URL=postgres://postgres:password@e2e-auth-postgres:5435/auth
@@ -138,7 +142,7 @@ services:
       additional_contexts:
         - common=./
     environment:
-      - CI=${CI}
+      - CI=${CI:-true}
       - PLAYWRIGHT_BASE_URL=http://app.taimei-code.local:3001
       - APP_BASE_URL=http://app.taimei-code.local:3001
       - AUTH_BASE_URL=http://auth.taimei-code.local:3100

--- a/e2e/tests/utils/signIn.ts
+++ b/e2e/tests/utils/signIn.ts
@@ -1,5 +1,5 @@
 import { Browser, BrowserContext } from "@playwright/test";
-import { eq, desc } from "drizzle-orm";
+import { desc } from "drizzle-orm";
 
 import { authDb } from "../../db/auth-client";
 import { user, verification } from "../../db/auth-schema";
@@ -30,21 +30,31 @@ export async function createTestUser(): Promise<string> {
 }
 
 // Server Action の非同期処理完了を待つため、トークンが見つかるまでポーリング (最大 20s)。
+// Better Auth 1.5.6 の magic-link plugin は verification.value に
+//   { email, name?, attempt: number }
+// の JSON を保存するため、完全一致でなく email キーで post-filter する。
+// (storeToken の default は "plain" のため identifier = raw token と一致。)
 export async function getVerificationToken(
   email: string,
   options: { maxRetries?: number; retryDelay?: number } = {},
 ): Promise<string> {
   const { maxRetries = 20, retryDelay = 1000 } = options;
-  const expectedValue = JSON.stringify({ email });
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
-    const record = await authDb
+    const records = await authDb
       .select()
       .from(verification)
-      .where(eq(verification.value, expectedValue))
       .orderBy(desc(verification.createdAt))
-      .limit(1)
-      .then((rows) => rows[0]);
+      .limit(20);
+
+    const record = records.find((r) => {
+      try {
+        const parsed = JSON.parse(r.value);
+        return parsed.email === email;
+      } catch {
+        return false;
+      }
+    });
 
     if (record) {
       return record.identifier;


### PR DESCRIPTION
## やったこと
- `e2e/tests/utils/signIn.ts`: `getVerificationToken` を post-filter ベース化 (Better Auth value format `{email,name?,attempt}` に対応)
- `docker-compose.e2e.yml`:
  - `e2e-auth-service.command` に `bunx drizzle-kit migrate &&` 追加
  - `e2e-auth-service.build.args` に `APP_ENV=test` 追加
  - `e2e.environment.CI` を `${CI:-true}` で default true (Playwright reporter が hang しない)

## なぜやるのか
Phase 1 期間中に taimei-auth の docker build / e2e フローを一度も走らせていなかったため検出漏れた問題群:

1. **value format 不一致**: Better Auth は `{"email":"x","attempt":0}` 形式で保存するが、helper は `{"email":"x"}` で完全一致 SELECT → マッチしない
2. **migration が起動時に走らない**: e2e-auth-service の command override がなく、`relation "user" does not exist`
3. **build args APP_ENV 未設定**: taimei-auth Vite が production allowlist だけ embed (PR #17 と対) 
4. **Playwright reporter の hang**: non-CI mode で `open: "always"` の reporter server が exit せず `--abort-on-container-exit` が効かない

## 関連 PR
- taimei-auth #16 (drizzle migration)
- taimei-auth #17 (build args + storeInDatabase + allowlist)

## 動作確認
ローカル e2e で 9 spec 中 6 件 pass を確認 (修正前は 2 件)。残り 3 件は SPA 画面の locator timeout で別系統 (別 PR で調査)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)