### PR TITLE
fix(auth): proxy.ts の returnTo を NEXT_PUBLIC_APP_URL ベースに + e2e build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,14 @@ COPY --chown=${username}:${username} . .
 # パフォーマンス向上のため、vercelへの情報提供を抑止
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Next.js は NEXT_PUBLIC_* を build 時に bundle / middleware へ static replace するため
+# build args で渡す必要がある (runtime env で override 不可)。production / e2e で
+# 異なる host を渡すため Dockerfile では ARG のみ宣言し、 docker-compose 側で値を渡す。
+ARG NEXT_PUBLIC_APP_URL
+ENV NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
+ARG NEXT_PUBLIC_AUTH_URL
+ENV NEXT_PUBLIC_AUTH_URL=${NEXT_PUBLIC_AUTH_URL}
+
 # 開発環境で環境立ち上げの速度を上げたい場合、以下コマンドを実行して
 # 立ち上げること
 # $ docker compose build --build-arg APP_BUILD_CMD='' && docker compose up --watch

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -103,6 +103,8 @@ services:
       dockerfile: Dockerfile
       args:
         NPM_TOKEN: ${NPM_TOKEN}
+        NEXT_PUBLIC_APP_URL: http://app.taimei-code.local:3001
+        NEXT_PUBLIC_AUTH_URL: http://auth.taimei-code.local:3100
     ports:
       - "3001:3001"
     command: >

--- a/proxy.ts
+++ b/proxy.ts
@@ -14,6 +14,12 @@ import { buildAuthLoginUrl } from "@taimei-code/auth-client";
 const AUTH_URL =
   process.env.NEXT_PUBLIC_AUTH_URL ?? "https://auth.taimei-code.com";
 
+// Next.js v16 middleware の request.url は internal listen address (例: localhost:3001) を
+// 返すケースがあり、Layer B の URL allowlist で弾かれる。NEXT_PUBLIC_APP_URL を base に
+// pathname + search を組んで明示的に絶対 URL を作る。
+const APP_URL =
+  process.env.NEXT_PUBLIC_APP_URL ?? "https://app.taimei-code.com";
+
 export default async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -36,10 +42,11 @@ export default async function proxy(request: NextRequest) {
   });
 
   if (!sessionCookie) {
+    const returnTo = `${APP_URL}${pathname}${request.nextUrl.search}`;
     const url = buildAuthLoginUrl({
       authBaseUrl: AUTH_URL,
       service: "taimei",
-      returnTo: request.url,
+      returnTo,
     });
     return NextResponse.redirect(url);
   }


### PR DESCRIPTION
## やったこと
- `proxy.ts`: `returnTo` を `request.url` (Next.js v16 で internal listen address = localhost:3001 を返すケースあり) から `NEXT_PUBLIC_APP_URL + pathname + search` に変更
- `Dockerfile`: `ARG NEXT_PUBLIC_APP_URL` / `ARG NEXT_PUBLIC_AUTH_URL` を追加し build 時に env として展開
- `docker-compose.e2e.yml`: `e2e-application.build.args` に上記 2 env を渡す

## なぜやるのか
Next.js v16 middleware で `request.url` が internal listen address を返し、`returnTo` が `http://localhost:3001/dashboard` で組み立てられて Layer B の URL allowlist に弾かれていた。`NEXT_PUBLIC_APP_URL` を base に明示的に絶対 URL を組む。

`NEXT_PUBLIC_*` は Next.js が build 時に bundle / middleware へ static replace するため runtime env で override 不可。production / e2e で異なる host を渡すため Dockerfile では ARG のみ宣言し、 docker-compose 側で値を渡す形にする。

## 動作確認
ローカル e2e で 9 spec 全 pass を確認 (修正前は :15 が常時 fail で SPA route 問題を起こしていた)。

## 関連 PR
- taimei-auth #15 (Dockerfile fix)
- taimei-auth #16 (drizzle migration)
- taimei-auth #17 (build args + storeInDatabase + allowlist)
- taimei-auth #18 (auth-client baseURL 絶対 URL 化)
- taimei #478 (signIn helper + migrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)