### PR TITLE
fix(test): UserService.delete mock の型不一致を修正

### DIFF
--- a/app/services/__tests__/user-service.test.ts
+++ b/app/services/__tests__/user-service.test.ts
@@ -197,7 +197,7 @@ describe("UserService", () => {
   describe("delete", () => {
     it("成功時 void", async () => {
       const mock = createMockUserService({
-        delete: () => Effect.succeed(undefined as void),
+        delete: (_id: string) => Effect.succeed(undefined),
       });
       const result = await runWithMock(
         Effect.gen(function* () {


### PR DESCRIPTION
## やったこと
mock 実装の型シグネチャを UserService の interface に合わせる。

\`\`\`diff
- delete: () => Effect.succeed(undefined as void),
+ delete: (_id: string) => Effect.succeed(undefined),
\`\`\`

## なぜやるのか
TS2322: 引数欠如 (\`() => ...\` vs \`(id: string) => ...\`) と戻り値型不一致 (\`void\` vs \`undefined\`) で型エラー。

## 動作確認
\`bun tsc --noEmit\` で当該エラーが消えることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)