### PR TITLE
chore(ci): actions/checkout を v4 から v6 に upgrade

### DIFF
--- a/.github/workflows/drizzle-migrate-deploy.yml
+++ b/.github/workflows/drizzle-migrate-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       name: Production
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install bun
         uses: oven-sh/setup-bun@v1
       - name: Install dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # taimei-auth (sign 流 Layer B) を sibling path に clone。docker-compose.e2e.yml の
       # e2e-auth-service が build context: '../taimei-auth' を参照するため必須。

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -9,7 +9,7 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: List files in the repository

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## やったこと
4 つの workflow で \`actions/checkout@v4\` → \`actions/checkout@v6\` に更新。

- \`unit-test.yml\`
- \`drizzle-migrate-deploy.yml\`
- \`github-actions-demo.yml\`
- \`e2e.yml\`

## なぜやるのか
\`actions/checkout@v4\` は Node.js 20 ベースで 2026-06-02 までに deprecation 予定。 v6 (Node.js 24 base、 v6.0.2 が現時点の latest stable) に上げて警告を解消。

## 動作確認
local では確認不能 (CI 上で動作)。 GitHub Actions で次回 push 時に green を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)