### PR TITLE
feat(dev): docker-compose.yml を sign 流統合 + e2e/README + CLAUDE.md 整備

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,15 +4,37 @@
 
 ```bash
 bun install                        # パッケージインストール
-docker compose up --build --watch  # 開発環境起動
 bun run test:db                    # DB起動→全テスト→DB停止（推奨）
 bun vitest run <file_path>         # 特定ファイルテスト（test_db起動済み前提）
 bun eslint . --fix                 # ESLint自動修正
 bun tsc --noEmit                   # 型チェック
 bunx drizzle-kit generate          # マイグレーションSQL生成
 bunx drizzle-kit migrate           # マイグレーション適用
-E2E_SERVICE_COMMAND='npm test' docker compose -f docker-compose.e2e.yml up --build  # E2E
 ```
+
+### Local Dev (sign 流統合)
+
+```bash
+docker compose up --build --watch  # taimei + taimei-auth + DB×2 + Redis を統合起動
+```
+
+ブラウザは `http://app.taimei-code.local:3001` でアクセス。Magic Link は test mode で console 出力されるため `docker logs taimei-auth-service-1 | grep "Magic Link"` で URL を取得して手動コピペ。
+
+**前提**:
+- 親ディレクトリに `taimei-auth` を clone (build context `../taimei-auth`)
+- `/etc/hosts` に `127.0.0.1 app.taimei-code.local auth.taimei-code.local` を追加 (sudo 必要、 一度だけ)
+- `.env` に `NPM_TOKEN=<read:packages 権限の GitHub PAT>` (GitHub Packages から `@taimei-code/auth-client` 取得用)
+- port 3001 が空いていること (`docker stop freee-mcp-grafana-1` で解放できる)
+
+### E2E (Playwright)
+
+```bash
+E2E_SERVICE_COMMAND='npm test' \
+  docker compose -p taimei-e2e -f docker-compose.e2e.yml \
+  up --build --abort-on-container-exit --exit-code-from e2e
+```
+
+`-p taimei-e2e` で dev compose と project / volume を分離。詳細は `e2e/README.md` 参照。
 
 ## Tech Stack
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -74,6 +74,8 @@ services:
       dockerfile: Dockerfile
       args:
         APP_ENV: test
+    ports:
+      - "3100:3100"
     command: >
       sh -c "bunx drizzle-kit migrate && bun run src/index.ts"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,19 @@
 volumes:
   pg-data:
+  auth-pg-data:
 
+# 同一 network 内で network alias によりコンテナ名と独立した DNS 名を提供。
+# - app.taimei-code.local → application (taimei, port 3001)
+# - auth.taimei-code.local → auth-service (taimei-auth, port 3100)
+# Cookie domain (.taimei-code.local) を共有し cross-subdomain SSO を成立させる。
+# dev / e2e で同じ host name + port を採用しているため /etc/hosts 設定は 1 度で済む。
 networks:
-  auth-net:
-    external: true
-    name: taimei-auth_default
+  taimei-network:
+    name: taimei-network
+    driver: bridge
 
 services:
+  # taimei (Next.js) 用 DB
   postgres:
     image: postgres:16.8-alpine3.21
     volumes:
@@ -26,7 +33,10 @@ services:
       interval: 3s
       timeout: 3s
       retries: 5
+    networks:
+      - taimei-network
 
+  # vitest 用 DB (dbEffect / withRollback で利用)
   test_db:
     image: postgres:16.8-alpine3.21
     ports:
@@ -40,24 +50,99 @@ services:
       interval: 3s
       timeout: 3s
       retries: 5
+    networks:
+      - taimei-network
 
+  # taimei-auth 用 DB (sign 流の Layer B / Better Auth が利用)
+  auth-postgres:
+    image: postgres:16.8-alpine3.21
+    volumes:
+      - auth-pg-data:/var/lib/postgresql/data
+    ports:
+      - "5435:5435"
+    environment:
+      - POSTGRES_DB=auth
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - PGPORT=5435
+    healthcheck:
+      test: pg_isready -U postgres -d auth
+      interval: 3s
+      timeout: 3s
+      retries: 5
+    networks:
+      - taimei-network
+
+  # taimei-auth 用 Redis (Better Auth secondary storage)
+  auth-redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 3s
+      retries: 5
+    networks:
+      - taimei-network
+
+  # taimei-auth (Hono + Bun, Layer B 含む) — sibling repo (../taimei-auth) を build context にする。
+  # APP_ENV=development で services.ts の allowlist が .local を許可する (PR #20)。
+  auth-service:
+    build:
+      context: '../taimei-auth'
+      dockerfile: Dockerfile
+      args:
+        APP_ENV: development
+    command: >
+      sh -c "bunx drizzle-kit migrate && bun run src/index.ts"
+    ports:
+      - "3100:3100"
+    environment:
+      - PORT=3100
+      - DATABASE_URL=postgres://postgres:password@auth-postgres:5435/auth
+      - REDIS_URL=redis://auth-redis:6379
+      - AUTH_SERVICE_URL=http://auth.taimei-code.local:3100
+      - AUTH_COOKIE_DOMAIN=taimei-code.local
+      - AUTH_TRUSTED_ORIGINS=http://app.taimei-code.local:3001,http://auth.taimei-code.local:3100
+      - APP_ENV=development
+      - APP_NAME=taimei
+      - AUTH_SECRET=dev-secret-for-local-development-32chars
+    depends_on:
+      auth-postgres:
+        condition: service_healthy
+      auth-redis:
+        condition: service_healthy
+    networks:
+      taimei-network:
+        aliases:
+          - auth.taimei-code.local
+
+  # taimei (Next.js dev server) — Layer B 経由で sign 流 ログインを行う
   application:
     build:
       context: '.'
       dockerfile: Dockerfile
+      args:
+        NPM_TOKEN: ${NPM_TOKEN}
+        NEXT_PUBLIC_APP_URL: http://app.taimei-code.local:3001
+        NEXT_PUBLIC_AUTH_URL: http://auth.taimei-code.local:3100
+        # APP_BUILD_CMD="" で Dockerfile の RUN ${APP_BUILD_CMD} を skip する。
+        # next dev (turbopack) が runtime コンパイルするため build 段階は不要。
+        APP_BUILD_CMD: ""
     ports:
-      - "3000:3000"
+      - "3001:3001"
     command: >
-      sh -c "bun dev"
+      sh -c "bunx drizzle-kit migrate && bun dev"
     user: vscode
     environment:
       - DATABASE_URL=postgres://postgres:password@postgres:5432/postgres
-      - AUTH_SERVICE_URL=http://auth-service:3100
-      - NEXT_PUBLIC_AUTH_SERVICE_URL=http://localhost:3100
-      - AUTH_SERVICE_KEY=${AUTH_SERVICE_KEY:-}
-    networks:
-      - default
-      - auth-net
+      - APP_ENV=development
+      - PORT=3001
+      - NEXT_PUBLIC_APP_URL=http://app.taimei-code.local:3001
+      - NEXT_PUBLIC_AUTH_URL=http://auth.taimei-code.local:3100
+      - AUTH_SERVICE_URL=http://auth.taimei-code.local:3100
+      - AUTH_TRUSTED_ORIGINS=http://app.taimei-code.local:3001,http://auth.taimei-code.local:3100
+      - AUTH_COOKIE_DOMAIN=taimei-code.local
+      - AUTH_SECRET=dev-secret-for-local-development-32chars
     develop:
       watch:
         - action: sync
@@ -68,3 +153,9 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      auth-service:
+        condition: service_started
+    networks:
+      taimei-network:
+        aliases:
+          - app.taimei-code.local

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,122 @@
+# E2E テスト
+
+Playwright + Docker Compose で taimei + taimei-auth (sign 流) を統合的に検証する。
+
+## 構成
+
+```
+docker-compose.e2e.yml
+├── e2e-postgres        (taimei DB, port 5433)
+├── e2e-auth-postgres   (taimei-auth DB, port 5435)
+├── e2e-auth-redis      (Better Auth secondary storage)
+├── e2e-auth-service    (taimei-auth, port 3100, alias: auth.taimei-code.local)
+├── e2e-application     (taimei Next.js, port 3001, alias: app.taimei-code.local)
+└── e2e                 (Playwright runner)
+```
+
+すべて同じ `e2e-network` 内で `app/auth.taimei-code.local` を network alias で解決する。Cookie domain `.taimei-code.local` で cross-subdomain SSO を成立させる。
+
+## 前提
+
+### 1. `/etc/hosts` 設定 (一度だけ)
+
+ブラウザから host port 経由でアクセスする場合のみ必要。Playwright runner は同 network 内で動くため不要。
+
+```bash
+sudo sh -c 'echo "127.0.0.1 app.taimei-code.local auth.taimei-code.local" >> /etc/hosts'
+```
+
+### 2. `NPM_TOKEN`
+
+`@taimei-code/auth-client` (GitHub Packages, private) を build 時に install するため `read:packages` 権限を持つ GitHub PAT が必要。プロジェクトルート `.env` に書いておけば docker compose が自動読み込み。
+
+### 3. taimei-auth sibling repo
+
+`docker-compose.e2e.yml` は `context: '../taimei-auth'` を参照する。同じ親ディレクトリに taimei-auth を clone しておく:
+
+```
+parent/
+├── taimei/
+└── taimei-auth/   ← 必須
+```
+
+### 4. port 衝突回避
+
+dev container や grafana 等が port 3001/3100/5433/5435 を占有していないこと:
+
+```bash
+docker stop freee-mcp-grafana-1 2>/dev/null   # 例: 3001 占有を解放
+```
+
+## 実行
+
+### 全テスト実行
+
+```bash
+E2E_SERVICE_COMMAND='npm test' \
+  docker compose -p taimei-e2e -f docker-compose.e2e.yml \
+  up --build --abort-on-container-exit --exit-code-from e2e
+```
+
+`-p taimei-e2e` は dev compose (`docker-compose.yml`) と project / volume を分離するため必須。
+
+### 特定 spec のみ実行 (高速)
+
+```bash
+E2E_SERVICE_COMMAND='npx playwright test --grep "未認証で保護ルート" --reporter=line --retries=0' \
+  docker compose -p taimei-e2e -f docker-compose.e2e.yml \
+  up --build --abort-on-container-exit --exit-code-from e2e
+```
+
+### Cleanup
+
+```bash
+docker compose -p taimei-e2e -f docker-compose.e2e.yml down
+```
+
+`--volumes` を付けると `auth-pg-data` / `pg-data` も削除される (DB を完全リセットしたい時)。
+
+## ログの確認
+
+### Magic Link URL の取得 (test mode で console 出力)
+
+```bash
+docker logs taimei-e2e-e2e-auth-service-1 2>&1 | grep "Magic Link"
+# → [TEST] Magic Link for foo@example.com: http://auth.taimei-code.local:3100/api/auth/magic-link/verify?token=xxx&callbackURL=...
+```
+
+### Playwright HTML report
+
+`./playwright-report/index.html` (test 結果)
+`./test-results/<test-name>/error-context.md` + `trace.zip` (失敗時の DOM snapshot / 再生)
+
+## test 構成
+
+| spec | 内容 |
+|------|------|
+| `auth.spec.ts` | sign 流の認証フロー全 7 件 (未認証 redirect / Magic Link / Layer B 画面遷移 / Error 画面) |
+| `dashboard.spec.ts` | dashboard ページの表示確認 |
+
+`tests/utils/signIn.ts` の `signInWithMagicLink` helper が:
+1. `/api/auth/sign-in/magic-link` を fetch (verification record DB 書き込み)
+2. `verification` table を post-filter で検索 (Better Auth の value format `{email,name?,attempt}` 対応)
+3. raw token を `/api/auth/magic-link/verify?token=...` に渡す
+4. Set-Cookie を BrowserContext に注入 (cross-subdomain `.taimei-code.local`)
+
+## トラブルシューティング
+
+### `Verification token not found after 20 attempts`
+→ Better Auth が `secondaryStorage` (Redis) のみに保存している。`taimei-auth/src/auth.ts` で `verification.storeInDatabase: isTestEnvironment()` が設定されていることを確認。
+
+### SPA 画面が真っ白 / locator timeout
+→ Vite bundle に `local` allowlist が含まれていない可能性。`docker exec taimei-e2e-e2e-auth-service-1 grep -c "local" web/dist/assets/*.js` で確認。0 件なら `APP_ENV=test` build args が docker-compose.e2e.yml で渡っているか確認。
+
+### `relation "user" does not exist`
+→ migration 未実行。`e2e-auth-service.command` に `bunx drizzle-kit migrate` が含まれていることを確認。
+
+### port 3001 衝突
+→ `docker stop freee-mcp-grafana-1` 等で占有プロセスを停止。
+
+## ローカル開発時の動作確認 (e2e と別)
+
+実際にブラウザで sign 流を動かす場合は **dev compose (`docker-compose.yml`)** を使う。詳細は project ルートの `CLAUDE.md` 参照。


### PR DESCRIPTION
## やったこと
- \`docker-compose.yml\`: e2e compose と同等構造に書き換え (taimei + taimei-auth + DB×2 + Redis を 1 ファイル統合、 port は e2e と同じ 3001/3100、 cookie domain \`taimei-code.local\`、 next dev で hot reload)
- \`docker-compose.e2e.yml\`: \`e2e-auth-service\` に host port 公開 (\`3100:3100\`) 追加
- \`e2e/README.md\`: 新規作成 (構成 / 起動手順 / Magic Link 取得 / トラブルシューティング)
- \`.claude/CLAUDE.md\`: Commands に Local Dev / E2E の sign 流対応コマンドを記載

## なぜやるのか
Phase 1 完了後、 dev compose は **旧 auth 時代のまま** で sign 流ローカル動作確認に使えなかった。 PR12a で e2e compose だけ統合したのが見落とし。 dev compose を整備して \`docker compose up --build --watch\` でローカル動作確認できるようにする。

## 設計判断
dev / e2e で host name と port を統一 (\`app/auth.taimei-code.local\` + 3001/3100)。 同時起動しない前提で、 \`/etc/hosts\` 設定が一度で済むことを優先。

## 関連 PR
- taimei-auth #20 (services.ts allowlist を APP_ENV !== production に拡張、 dev mode 対応)

## 動作確認
- \`docker compose -f docker-compose.yml config --quiet\` で YAML 妥当性確認
- 実起動は \`docker compose up --build --watch\` でローカル確認 (CI 不要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)