### PR TITLE
chore: 未使用の .claude/settings.json を削除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,0 @@
-{
-  "plansDirectory": "./plans"
-}


### PR DESCRIPTION
## Summary
- `.claude/settings.json` の `plansDirectory` 設定はコードベースで参照されていないため削除

## Test plan
- [x] `grep -r plansDirectory` でリポジトリ内に参照がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)