### PR TITLE
chore(docs): README に Mac ローカル動作確認手順を追加し、暗黙文脈を排除

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,29 +12,9 @@ bunx drizzle-kit generate          # マイグレーションSQL生成
 bunx drizzle-kit migrate           # マイグレーション適用
 ```
 
-### Local Dev (sign 流統合)
+### Local Dev / E2E
 
-```bash
-docker compose up --build --watch  # taimei + taimei-auth + DB×2 + Redis を統合起動
-```
-
-ブラウザは `http://app.taimei-code.local:3001` でアクセス。Magic Link は test mode で console 出力されるため `docker logs taimei-auth-service-1 | grep "Magic Link"` で URL を取得して手動コピペ。
-
-**前提**:
-- 親ディレクトリに `taimei-auth` を clone (build context `../taimei-auth`)
-- `/etc/hosts` に `127.0.0.1 app.taimei-code.local auth.taimei-code.local` を追加 (sudo 必要、 一度だけ)
-- `.env` に `NPM_TOKEN=<read:packages 権限の GitHub PAT>` (GitHub Packages から `@taimei-code/auth-client` 取得用)
-- port 3001 が空いていること (`docker stop freee-mcp-grafana-1` で解放できる)
-
-### E2E (Playwright)
-
-```bash
-E2E_SERVICE_COMMAND='npm test' \
-  docker compose -p taimei-e2e -f docker-compose.e2e.yml \
-  up --build --abort-on-container-exit --exit-code-from e2e
-```
-
-`-p taimei-e2e` で dev compose と project / volume を分離。詳細は `e2e/README.md` 参照。
+開発環境起動・前提条件・Magic Link 取得・Mac ブラウザでのローカル動作確認・E2E 実行手順は `README.md` を参照。
 
 ## Tech Stack
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # taimei-auth (sign 流 Layer B) を sibling path に clone。docker-compose.e2e.yml の
+      # taimei-auth (認証サーバー) を sibling path に clone。docker-compose.e2e.yml の
       # e2e-auth-service が build context: '../taimei-auth' を参照するため必須。
       # public repo なので認証不要。
       - name: Clone taimei-auth (sibling)

--- a/README.md
+++ b/README.md
@@ -3,53 +3,88 @@
 心安らかなソリューション。
 それが Taimei
 
-# パッケージインストール
+## パッケージインストール
 
-## アプリケーション用
+### アプリケーション用
 
 ```console
 bun install
 ```
 
-## e2e 用
+### e2e 用
 
 ```console
 npm --prefix ./e2e install ./e2e
 ```
 
-# データベースマイグレーション
+## データベースマイグレーション
 
 ```console
 bunx drizzle-kit migrate
 ```
 
-# 開発環境起動
+## 開発環境起動
 
-`--watch`オプションを指定するとホットリロードが可能です。
+`taimei + taimei-auth (認証サーバー) + DB×2 + Redis` を統合起動する。`--watch` でホットリロード。
 
 ```console
 docker compose up --build --watch
 ```
 
-上記コマンド実行後、以下コマンドを実行して立ち上げると起動時間が早くなります。
-（ただし、ローカルアプリケーションの速度は上記と比べて遅くなります）
+ブラウザは `http://app.taimei-code.local:3001` でアクセス。
+
+### 前提
+
+- 親ディレクトリに `taimei-auth` を clone (build context `../taimei-auth`)
+- `/etc/hosts` に `127.0.0.1 app.taimei-code.local auth.taimei-code.local` を追加 (sudo 必要、一度だけ)
+- `.env` に `NPM_TOKEN=<read:packages 権限の GitHub PAT>` (GitHub Packages から `@taimei-code/auth-client` 取得用)
+- port 3001 が空いていること (`docker stop freee-mcp-grafana-1` で解放できる)
+
+### Magic Link
+
+Magic Link は test mode で console 出力されるため、以下で URL を取得して手動コピペする:
+
+```console
+docker logs taimei-auth-service-1 | grep "Magic Link"
+```
+
+### ビルド時間短縮 (任意)
+
+ビルドキャッシュを効かせて起動を高速化したい場合 (ローカルアプリの実行速度は遅くなる):
 
 ```console
 docker compose build --build-arg APP_BUILD_CMD='' && docker compose up --watch
 ```
 
-# テストコマンド
+### Mac ブラウザでのローカル動作確認 (2026-05-05 完了)
 
-## e2e テスト
+`docker compose up --build --watch` でローカル動作確認:
+
+1. AWS EC2 上で claude code が docker compose 起動 (ports 3001/3100 公開)
+2. Mac から VSCode Remote SSH の auto port forwarding 経由で localhost:3001 へ到達
+3. Mac の `/etc/hosts` に `127.0.0.1 app.taimei-code.local auth.taimei-code.local` を追加
+4. ブラウザ `http://app.taimei-code.local:3001/dashboard` → taimei-auth の SignIn 画面に redirect
+5. メアド入力 → 「Magic Link を送信」→ `docker logs taimei-auth-service-1 | grep "Magic Link"` で URL 取得
+6. URL を Chrome で開く → /dashboard 着地 ✅
+
+これで認証統合のエンドツーエンド動作 (proxy → taimei-auth → Magic Link → cookie → /dashboard) が手動で確認できた。`.local` TLD は Mac の Bonjour 解決で問題になる可能性があったが今回は無事動作。
+
+## E2E テスト
 
 ```console
-E2E_SERVICE_COMMAND='npm test' docker compose -f docker-compose.e2e.yml up --build
+E2E_SERVICE_COMMAND='npm test' \
+  docker compose -p taimei-e2e -f docker-compose.e2e.yml \
+  up --build --abort-on-container-exit --exit-code-from e2e
 ```
 
-## e2e テスト（UI モード）
+`-p taimei-e2e` で dev compose と project / volume を分離。詳細は `e2e/README.md` 参照。
+
+### UI モード
 
 ```console
-E2E_SERVICE_COMMAND='npm run test-ui' docker compose -f docker-compose.e2e.yml up --build --watch
+E2E_SERVICE_COMMAND='npm run test-ui' \
+  docker compose -p taimei-e2e -f docker-compose.e2e.yml \
+  up --build --watch
 ```
 
 # TODO

--- a/app/auth/after-signin/page.tsx
+++ b/app/auth/after-signin/page.tsx
@@ -4,10 +4,10 @@ import { Effect, Either } from "effect";
 import { getSession } from "@/app/lib/auth-guard";
 import { runService, UserProfileService } from "@/app/services";
 
-// Better Auth のログイン後着地点 (sign 流)。Layer B から callbackURL=https://app.taimei-code.com/auth/after-signin に飛んでくる。
+// Better Auth のログイン後着地点。taimei-auth から callbackURL=https://app.taimei-code.com/auth/after-signin に飛んでくる。
 //
 // 分岐:
-// (1) 未認証 (session なし) → Layer B の error 画面に誘導 (signin_failed)
+// (1) 未認証 (session なし) → taimei-auth の error 画面に誘導 (signin_failed)
 // (2) profile が DB に存在しない (初回ログイン) → /setting/profile で補完誘導
 // (3) profile 既存 → /dashboard
 //

--- a/app/auth/after-signup/page.tsx
+++ b/app/auth/after-signup/page.tsx
@@ -2,11 +2,11 @@ import { redirect } from "next/navigation";
 
 import { getSession } from "@/app/lib/auth-guard";
 
-// Better Auth のサインアップ後着地点 (sign 流)。Layer B SignUp から callbackURL=https://app.taimei-code.com/auth/after-signup に飛んでくる。
+// Better Auth のサインアップ後着地点。taimei-auth の SignUp から callbackURL=https://app.taimei-code.com/auth/after-signup に飛んでくる。
 //
 // 分岐:
-// (1) 未認証 → Layer B の error 画面に誘導
-// (2) createdAt が 5 分以上前 → 既存ユーザーが /auth/signup に来た = 二重サインアップ → Layer B の error 画面 (signup_already_completed)
+// (1) 未認証 → taimei-auth の error 画面に誘導
+// (2) createdAt が 5 分以上前 → 既存ユーザーが /auth/signup に来た = 二重サインアップ → taimei-auth の error 画面 (signup_already_completed)
 // (3) 新規ユーザー → /setting/profile?welcome=1 で profile 補完を促す (welcome 表示は profile 画面側に統合)
 //
 // 5 分の根拠: Better Auth Magic Link の expiresIn=300 と一致 — Magic Link クリック後 5 分以内なら新規。

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -35,7 +35,7 @@ services:
     networks:
       - e2e-network
 
-  # taimei-auth 用 DB (sign 流の Layer B / Better Auth が利用)
+  # taimei-auth (認証サーバー) 用 DB — Better Auth が利用
   e2e-auth-postgres:
     image: postgres:16.8-alpine3.21
     volumes:
@@ -66,8 +66,8 @@ services:
     networks:
       - e2e-network
 
-  # taimei-auth (Hono + Bun, Layer B 含む) — sibling repo を build context にする。
-  # CI で実行する場合は taimei-auth も checkout 必要 (e2e.yml で対応予定 PR12b)。
+  # taimei-auth (認証サーバー, Hono + Bun) — sibling repo を build context にする。
+  # CI では .github/workflows/e2e.yml で taimei-auth を sibling path に clone する。
   e2e-auth-service:
     build:
       context: '../taimei-auth'
@@ -98,7 +98,7 @@ services:
         aliases:
           - auth.taimei-code.local
 
-  # taimei (Next.js) — Layer B 経由で sign 流 ログインを行う
+  # taimei (Next.js) — taimei-auth 経由でログインを行う
   e2e-application:
     build:
       context: '.'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     networks:
       - taimei-network
 
-  # taimei-auth 用 DB (sign 流の Layer B / Better Auth が利用)
+  # taimei-auth (認証サーバー) 用 DB — Better Auth が利用
   auth-postgres:
     image: postgres:16.8-alpine3.21
     volumes:
@@ -84,8 +84,8 @@ services:
     networks:
       - taimei-network
 
-  # taimei-auth (Hono + Bun, Layer B 含む) — sibling repo (../taimei-auth) を build context にする。
-  # APP_ENV=development で services.ts の allowlist が .local を許可する (PR #20)。
+  # taimei-auth (認証サーバー, Hono + Bun) — sibling repo (../taimei-auth) を build context にする。
+  # APP_ENV=development で taimei-auth 側 services.ts の allowlist が .local を許可する。
   auth-service:
     build:
       context: '../taimei-auth'
@@ -116,7 +116,7 @@ services:
         aliases:
           - auth.taimei-code.local
 
-  # taimei (Next.js dev server) — Layer B 経由で sign 流 ログインを行う
+  # taimei (Next.js dev server) — taimei-auth 経由でログインを行う
   application:
     build:
       context: '.'

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,6 +1,6 @@
 # E2E テスト
 
-Playwright + Docker Compose で taimei + taimei-auth (sign 流) を統合的に検証する。
+Playwright + Docker Compose で taimei + taimei-auth (認証サーバー) を統合的に検証する。
 
 ## 構成
 
@@ -94,7 +94,7 @@ docker logs taimei-e2e-e2e-auth-service-1 2>&1 | grep "Magic Link"
 
 | spec | 内容 |
 |------|------|
-| `auth.spec.ts` | sign 流の認証フロー全 7 件 (未認証 redirect / Magic Link / Layer B 画面遷移 / Error 画面) |
+| `auth.spec.ts` | taimei-auth 経由の認証フロー全 7 件 (未認証 redirect / Magic Link / taimei-auth 画面遷移 / Error 画面) |
 | `dashboard.spec.ts` | dashboard ページの表示確認 |
 
 `tests/utils/signIn.ts` の `signInWithMagicLink` helper が:
@@ -119,4 +119,4 @@ docker logs taimei-e2e-e2e-auth-service-1 2>&1 | grep "Magic Link"
 
 ## ローカル開発時の動作確認 (e2e と別)
 
-実際にブラウザで sign 流を動かす場合は **dev compose (`docker-compose.yml`)** を使う。詳細は project ルートの `CLAUDE.md` 参照。
+実際にブラウザで認証フローを動かす場合は **dev compose (`docker-compose.yml`)** を使う。詳細は project ルートの `README.md` 参照。

--- a/e2e/db/auth-schema.ts
+++ b/e2e/db/auth-schema.ts
@@ -7,7 +7,7 @@ import {
   uniqueIndex,
 } from "drizzle-orm/pg-core";
 
-// taimei-auth (Layer B + Better Auth) DB の Better Auth schema (e2e helper 用、最小セット)。
+// taimei-auth (認証サーバー, Better Auth) DB の schema (e2e helper 用、最小セット)。
 // signIn helper が verification token を取得するために必要な user / verification のみ定義。
 // session / account は signIn フローでの参照不要。
 export const user = pgTable(

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,8 +21,8 @@ export default defineConfig({
     : [["html", { host: "0.0.0.0", port: "9323", open: "always" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */ use: {
     /* Base URL to use in actions like `await page.goto('/')`.
-     * sign 流: APP_BASE_URL (taimei) を baseURL に固定。AUTH_BASE_URL (taimei-auth) は
-     * signIn helper / spec 内で個別に組み立てる (cross-origin のため). */
+     * APP_BASE_URL (taimei) を baseURL に固定。AUTH_BASE_URL (taimei-auth) は
+     * cross-origin のため signIn helper / spec 内で個別に組み立てる。 */
     baseURL: process.env.APP_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -7,12 +7,12 @@ import {
   verifyMagicLinkAndGetContext,
 } from "./utils/signIn";
 
-// sign 流 (PR5b/PR7 で確立) の e2e。Layer B (taimei-auth) 経由ログインを検証する。
+// taimei-auth (認証サーバー) 経由ログインを検証する e2e。
 // taimei への未認証アクセス → proxy が AUTH_BASE_URL/auth/?service_name=taimei&redirect_url=... に redirect。
-// Layer B の SignIn 画面でフォーム送信 → Magic Link verify → taimei /auth/after-signin → /dashboard。
-test.describe("認証フロー (sign 流)", () => {
+// taimei-auth の SignIn 画面でフォーム送信 → Magic Link verify → taimei /auth/after-signin → /dashboard。
+test.describe("認証フロー", () => {
   test.describe("保護ルートへの未認証アクセス", () => {
-    test("未認証で保護ルートにアクセスすると Layer B にリダイレクトされる", async ({
+    test("未認証で保護ルートにアクセスすると taimei-auth にリダイレクトされる", async ({
       page,
     }) => {
       await page.goto("/dashboard");
@@ -61,14 +61,14 @@ test.describe("認証フロー (sign 流)", () => {
     });
   });
 
-  test.describe("Layer B 経由の統合認証フロー", () => {
+  test.describe("taimei-auth 経由の統合認証フロー", () => {
     test("未登録メールで認証すると新規アカウントが作成される", async ({
       page,
       browser,
     }) => {
       const newEmail = `new-${Date.now()}@example.com`;
 
-      // Layer B の SignIn 画面を直接訪問 (service_name=taimei + redirect_url=...)
+      // taimei-auth の SignIn 画面を直接訪問 (service_name=taimei + redirect_url=...)
       const params = new URLSearchParams({
         service_name: "taimei",
         redirect_url: "http://app.taimei-code.local:3001/auth/after-signin",
@@ -132,7 +132,7 @@ test.describe("認証フロー (sign 流)", () => {
       await context.close();
     });
 
-    test("Layer B のエラー画面 (signin_failed) が表示される", async ({
+    test("taimei-auth のエラー画面 (signin_failed) が表示される", async ({
       page,
     }) => {
       await page.goto(`${AUTH_BASE_URL}/auth/error?reason=signin_failed`);

--- a/e2e/tests/utils/signIn.ts
+++ b/e2e/tests/utils/signIn.ts
@@ -4,12 +4,12 @@ import { desc } from "drizzle-orm";
 import { authDb } from "../../db/auth-client";
 import { user, verification } from "../../db/auth-schema";
 
-// sign 流 (PR5b/PR7 で taimei に統合) 対応の e2e signIn helper。
+// taimei-auth (認証サーバー) 経由ログイン用の e2e signIn helper。
 // taimei (app.taimei-code.local:3001) と taimei-auth (auth.taimei-code.local:3100) は別オリジン。
 // Magic Link 関連の API はすべて taimei-auth (AUTH_BASE_URL) に飛ばし、
 // 検証完了後 callbackURL = APP_BASE_URL/auth/after-signin に redirect させる。
 //
-// Cookie domain は AUTH_COOKIE_DOMAIN=taimei-code.local 設定済 (PR12a)。
+// Cookie domain は docker-compose の AUTH_COOKIE_DOMAIN=taimei-code.local で設定済。
 // Better Auth が Set-Cookie: Domain=.taimei-code.local で返すため、
 // Playwright BrowserContext に追加するときも同じ domain を指定する必要がある。
 export const APP_BASE_URL =
@@ -84,7 +84,7 @@ export async function signInWithMagicLink(
     throw new Error(`Magic link request failed: ${sendResp.status}`);
   }
 
-  // 2. DB から token を取得して verify。callbackURL は taimei /auth/after-signin (sign 流着地点)。
+  // 2. DB から token を取得して verify。callbackURL は taimei /auth/after-signin (taimei 側のログイン後着地点)。
   const token = await getVerificationToken(email);
   const verifyUrl = `${AUTH_BASE_URL}/api/auth/magic-link/verify?token=${token}&callbackURL=${encodeURIComponent(`${APP_BASE_URL}/auth/after-signin`)}`;
   const verifyResponse = await fetch(verifyUrl, { redirect: "manual" });

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,20 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSessionCookie } from "better-auth/cookies";
 import { buildAuthLoginUrl } from "@taimei-code/auth-client";
 
-// sign 流: 未認証なら taimei-auth (Layer B) に redirect。helper (PR5a) で URL 構築を集約することで
-// クエリ名 typo / 順序ぶれを防ぐ。Cookie 検証は各ページで行うのは旧設計と同じ。
+// 未認証なら taimei-auth (認証サーバー) に redirect。
+// @taimei-code/auth-client の buildAuthLoginUrl で URL 構築を集約し、クエリ名 typo / 順序ぶれを防ぐ。
 //
 // publicPaths:
 // - "/" : LP / 未認証で見える top page
 // - "/api/auth": Better Auth callback (OAuth 戻り URL の処理経路)
-// - "/auth/after-signin", "/auth/after-signup": Layer B からの着地点 (Cookie 設定の race condition
+// - "/auth/after-signin", "/auth/after-signup": taimei-auth からの着地点 (Cookie 設定の race condition
 //   回避のため proxy をスキップ、各ページ側で getSession() で null チェック実装済)
-// 旧 "/auth" は publicPaths から削除 (PR10a で page.tsx ごと削除予定、それまでは Layer B に redirect)。
 const AUTH_URL =
   process.env.NEXT_PUBLIC_AUTH_URL ?? "https://auth.taimei-code.com";
 
 // Next.js v16 middleware の request.url は internal listen address (例: localhost:3001) を
-// 返すケースがあり、Layer B の URL allowlist で弾かれる。NEXT_PUBLIC_APP_URL を base に
+// 返すケースがあり、taimei-auth の URL allowlist で弾かれる。NEXT_PUBLIC_APP_URL を base に
 // pathname + search を組んで明示的に絶対 URL を作る。
 const APP_URL =
   process.env.NEXT_PUBLIC_APP_URL ?? "https://app.taimei-code.com";


### PR DESCRIPTION
## Summary

- `~/.claude/plans/taimei/phase1-auth-ui-migration.md` の「Mac ブラウザでのローカル動作確認 (2026-05-05 完了)」を README に追記
- README と CLAUDE.md で重複していた dev / e2e 起動手順を README に集約 (CLAUDE.md からは README 参照のみに)
- このリポジトリ単独で読んだ人が理解できるよう、別リポジトリ・過去 PR への暗黙参照を排除:
  - `sign 流` → 削除
  - `Layer B` → `taimei-auth (認証サーバー)`
  - `PR5a / PR5b / PR7 / PR10a / PR12a / PR12b / PR #20` → 削除し、該当する設定ファイル名で言及
  - `旧設計` / `旧 "/auth"` → 削除
- 対象: `README.md` / `.claude/CLAUDE.md` / `proxy.ts` / `docker-compose*.yml` / `app/auth/after-{signin,signup}/page.tsx` / `.github/workflows/e2e.yml` / `e2e/**`

ロジック変更なし (コメント・ドキュメント・test describe / test 名のみ)。

## Test plan

- [ ] `bun tsc --noEmit` で型チェックが通る (コメントのみ変更だが念のため)
- [ ] e2e の `--grep "未認証で保護ルート"` 等、test 名を前方一致で参照する箇所が壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)