### PR TITLE
chore(docs): 環境依存の記述 (個人 container 名 / AWS EC2 / Mac 等) を排除

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker compose up --build --watch
 - 親ディレクトリに `taimei-auth` を clone (build context `../taimei-auth`)
 - `/etc/hosts` に `127.0.0.1 app.taimei-code.local auth.taimei-code.local` を追加 (sudo 必要、一度だけ)
 - `.env` に `NPM_TOKEN=<read:packages 権限の GitHub PAT>` (GitHub Packages から `@taimei-code/auth-client` 取得用)
-- port 3001 が空いていること (`docker stop freee-mcp-grafana-1` で解放できる)
+- port 3001 が空いていること (占有されている場合は `docker ps | grep 3001` で特定して `docker stop <container>` で解放)
 
 ### Magic Link
 
@@ -56,18 +56,18 @@ docker logs taimei-auth-service-1 | grep "Magic Link"
 docker compose build --build-arg APP_BUILD_CMD='' && docker compose up --watch
 ```
 
-### Mac ブラウザでのローカル動作確認 (2026-05-05 完了)
+### ブラウザでのローカル動作確認 (2026-05-05 完了)
 
 `docker compose up --build --watch` でローカル動作確認:
 
-1. AWS EC2 上で claude code が docker compose 起動 (ports 3001/3100 公開)
-2. Mac から VSCode Remote SSH の auto port forwarding 経由で localhost:3001 へ到達
-3. Mac の `/etc/hosts` に `127.0.0.1 app.taimei-code.local auth.taimei-code.local` を追加
+1. docker compose 起動 (ports 3001/3100 公開)
+2. リモート開発環境を使う場合は、ブラウザを動かすマシンへ port を到達可能にする (port forwarding / SSH tunnel 等。ローカル開発なら不要)
+3. ブラウザを動かす OS の `/etc/hosts` に `127.0.0.1 app.taimei-code.local auth.taimei-code.local` を追加
 4. ブラウザ `http://app.taimei-code.local:3001/dashboard` → taimei-auth の SignIn 画面に redirect
 5. メアド入力 → 「Magic Link を送信」→ `docker logs taimei-auth-service-1 | grep "Magic Link"` で URL 取得
-6. URL を Chrome で開く → /dashboard 着地 ✅
+6. URL をブラウザで開く → /dashboard 着地 ✅
 
-これで認証統合のエンドツーエンド動作 (proxy → taimei-auth → Magic Link → cookie → /dashboard) が手動で確認できた。`.local` TLD は Mac の Bonjour 解決で問題になる可能性があったが今回は無事動作。
+これで認証統合のエンドツーエンド動作 (proxy → taimei-auth → Magic Link → cookie → /dashboard) が手動で確認できた。`.local` TLD は macOS の Bonjour 解決で問題になる可能性があったが今回は無事動作。
 
 ## E2E テスト
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -42,10 +42,11 @@ parent/
 
 ### 4. port 衝突回避
 
-dev container や grafana 等が port 3001/3100/5433/5435 を占有していないこと:
+他の container や process が port 3001/3100/5433/5435 を占有していないこと。占有時は以下で特定して停止:
 
 ```bash
-docker stop freee-mcp-grafana-1 2>/dev/null   # 例: 3001 占有を解放
+docker ps | grep -E '3001|3100|5433|5435'   # 占有 container を特定
+docker stop <container>                      # 該当 container を停止
 ```
 
 ## 実行
@@ -115,7 +116,7 @@ docker logs taimei-e2e-e2e-auth-service-1 2>&1 | grep "Magic Link"
 → migration 未実行。`e2e-auth-service.command` に `bunx drizzle-kit migrate` が含まれていることを確認。
 
 ### port 3001 衝突
-→ `docker stop freee-mcp-grafana-1` 等で占有プロセスを停止。
+→ `docker ps | grep 3001` で占有 container を特定し、`docker stop <container>` で停止。
 
 ## ローカル開発時の動作確認 (e2e と別)
 


### PR DESCRIPTION
## Summary

リポジトリを clone した第三者にも通用する汎用表現に置換:

- `docker stop freee-mcp-grafana-1` (個人作業環境の container 名) → `docker ps | grep <port>` で特定して `docker stop <container>`
- 「Mac ブラウザでの動作確認」セクションの `AWS EC2 上で claude code が docker compose 起動` / `Mac から VSCode Remote SSH の auto port forwarding` → 「リモート開発環境を使う場合は port forwarding / SSH tunnel」と汎用化
- セクション題名 `Mac ブラウザでのローカル動作確認` → `ブラウザでのローカル動作確認`
- `URL を Chrome で開く` → `URL をブラウザで開く`

`.local` TLD の Bonjour 解決問題は OS-specific だが「macOS で発生しうる落とし穴」として情報価値があるため残置。

## Test plan

- [ ] README.md の手順をリポジトリを知らない人が読んで理解できる文面になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)