### PR TITLE
ci: lint ワークフローを追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Biome + ESLint
+        run: bun run lint
+
+      - name: Type check
+        run: bun tsc --noEmit


### PR DESCRIPTION
## やったこと
`bun run lint` (Biome + ESLint) と `bun tsc --noEmit` を回す GitHub Actions ワークフロー `.github/workflows/lint.yml` を新規作成した。`unit-test.yml` と同じ `actions/checkout@v6` / `oven-sh/setup-bun@v2` 構成。

## なぜやるのか
従来の CI は Vitest / Playwright / migration deploy しか回しておらず、整形・型エラーが merge を止めない状態だった。#488 で Biome を入れたタイミングに合わせて lint gate を CI に追加し、今後の整形逸脱と型エラー混入を防ぐ。

## 動作確認結果
- ローカルで `bun run lint` クリーン
- ローカルで `bun tsc --noEmit` パス
- ワークフロー自体の動作は GitHub Actions 上での push で初検証

## 関連
depends on #488 (PR #488 マージ後に main 向けへ自動 retarget される)
