### PR TITLE
docs(claude): Pitfalls セクションを追加 (運用上の罠を集約)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,3 +46,11 @@ Think in English, output in Japanese. コード内コメントも日本語。
 - Better Auth: `https://www.better-auth.com/llms.txt`
 - Next.js: `https://nextjs.org/docs/llms-full.txt`
 - Effect-TS: `https://effect.website/llms-full.txt`
+
+## Pitfalls
+
+### Git / GitHub
+- **Stacked PR の上流マージで `--delete-branch` を付けない**: 下流 PR が auto-close され reopen 不可になる (理由: GitHub は base ブランチが merge されると下流を auto-retarget するが、delete されると orphan として close する)。下流をマージし終わってから手動でブランチ削除する。
+
+### Lint / Formatter
+- **`// eslint-disable-next-line` は formatter の改行で無効化される**: 行番号依存のため Biome 等が改行を入れると disable 対象がズレる。複数行に渡る式を suppress するときは disable コメントを実際の違反行の直上に置くか、ブロック形式 (`/* eslint-disable */ ... /* eslint-enable */`) を使う。


### PR DESCRIPTION
## やったこと
`.claude/CLAUDE.md` に `## Pitfalls` セクションを追加。Git/GitHub と Lint/Formatter の運用上の罠を 2 件記載した。

## なぜやるのか
今回のセッション中に、`gh pr merge --delete-branch` で stacked PR の下流 (#489) を意図せず close させ、新規 PR (#490) として再発行する手戻りが発生した。同じ罠に再度はまらないよう、retrospective から抽出したルールをプロジェクト CLAUDE.md に固定する。Lint 側も Biome 導入で `eslint-disable-next-line` の行ズレに遭遇したため併せて記録した。

## 動作確認結果
- markdown レンダリング崩れなし (`.claude/CLAUDE.md` をローカルで確認)
- 既存セクション (Library Docs まで) には変更なし、末尾に追記のみ
