### PR TITLE
chore(lint): Biome rule で better-auth 直接 import を禁止 (ADR-004 Stage B)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -62,6 +62,18 @@
         "noCommonJs": "error",
         "noHeadElement": "warn",
         "noNamespace": "error",
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "better-auth": "ADR-004 により taimei では better-auth を直接 import 禁止。@taimei-code/auth-client を経由すること。",
+              "better-auth/react": "ADR-004 により React UI は taimei-auth でホスト。taimei では better-auth/react import 禁止。",
+              "better-auth/api": "ADR-004 により taimei では better-auth/api 直接 import 禁止。@taimei-code/auth-client/server を経由すること。",
+              "better-auth/client": "ADR-004 により taimei では better-auth/client 直接 import 禁止。@taimei-code/auth-client を経由すること。",
+              "better-auth/plugins": "ADR-004 により taimei では better-auth/plugins 直接 import 禁止。@taimei-code/auth-client が wrap した API を使うこと。"
+            }
+          }
+        },
         "useArrayLiterals": "error",
         "useAsConstAssertion": "error"
       },


### PR DESCRIPTION
## やったこと

`taimei/biome.json` の `linter.rules.style.noRestrictedImports` に better-auth 直接 import を禁止するルールを追加。
PR2 (#492) で実コードから消した better-auth 漏洩を、CI で再混入させないための防壁化。

## なぜやるのか

ADR-004 Stage B は「将来の漏洩を CI で防ぐガードレール」として計画。
Stage A (PR1+PR2) で漏洩を 0 件化した直後の今、ルール追加コストが最小 (既存違反ゼロ)。
別 IdP 移行時に taimei コードベースを無修正で済ませる契約を、人ではなく CI で守る。

## 動作確認結果

- `bun biome check .` (202 ファイル) pass、ルール認識成功
- 検証用に `import { something } from "better-auth"` を一時ファイルに記述 → biome が `lint/style/noRestrictedImports` error + ADR-004 誘導メッセージを出すことを確認、ファイルは削除済み

## 禁止対象

| パス | 代替 |
|---|---|
| `better-auth` | `@taimei-code/auth-client` |
| `better-auth/react` | UI は taimei-auth でホスト、taimei では使用禁止 |
| `better-auth/api` | `@taimei-code/auth-client/server` |
| `better-auth/client` | `@taimei-code/auth-client` |
| `better-auth/plugins` | `@taimei-code/auth-client` の wrap API |