### PR TITLE
refactor(auth): env と SDK client を lib/auth に singleton 集約 (ADR-005 Phase 1)

### DIFF
--- a/app/lib/auth-guard.ts
+++ b/app/lib/auth-guard.ts
@@ -1,24 +1,16 @@
 // クライアントサイドでの誤用を防止（セッション検証はサーバーサイドでのみ安全）
 import "server-only";
 import {
-  createAuthClient,
   createAuthGuard,
   getSessionTokenFromCookieStore,
 } from "@taimei-code/auth-client";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { cache } from "react";
-
-const authServiceUrl = process.env.AUTH_SERVICE_URL || "http://localhost:3100";
-const serviceKey = process.env.AUTH_SERVICE_KEY;
-
-const client = createAuthClient({
-  baseUrl: `${authServiceUrl}/rpc`,
-  serviceKey,
-});
+import { authClient } from "@/lib/auth/client";
 
 const guard = createAuthGuard({
-  client,
+  client: authClient,
   cache,
   redirect,
   getSessionToken: async () => {

--- a/app/services/auth-service.ts
+++ b/app/services/auth-service.ts
@@ -1,9 +1,7 @@
-import {
-  createAuthClient,
-  extractSessionTokenFromCookieHeader,
-} from "@taimei-code/auth-client";
+import { extractSessionTokenFromCookieHeader } from "@taimei-code/auth-client";
 import { Effect } from "effect";
 import { Email } from "@/app/domain/email";
+import { authClient } from "@/lib/auth/client";
 import {
   AuthServiceError,
   MagicLinkError,
@@ -11,21 +9,18 @@ import {
   SignOutError,
 } from "./auth-errors";
 
-const authServiceUrl = process.env.AUTH_SERVICE_URL || "http://localhost:3100";
-const serviceKey = process.env.AUTH_SERVICE_KEY;
-
 export class AuthService extends Effect.Service<AuthService>()(
   "services/AuthService",
   {
     effect: Effect.gen(function* () {
-      const { authService } = createAuthClient({
-        baseUrl: `${authServiceUrl}/rpc`,
-        serviceKey,
-      });
+      const { authService } = authClient;
 
       // next/headers は Server Component / Server Action 文脈外で import すると build error になるため、
       // try callback まで評価を遅延する目的で動的 import を使う。ES module キャッシュが効くので
       // 2 回目以降のオーバーヘッドはない。
+      // FIXME(ADR-005 Phase 2): auth-guard.ts は SDK helper (getSessionTokenFromCookieStore) 経由、
+      //   ここは生 cookie ヘッダ parse 経由と 2 系統に分裂している。CookieReader Effect.Service として
+      //   抽出し両者を統一する。新規 Service でこの動的 import パターンを真似しないこと。
       const readSessionToken = async (): Promise<string | undefined> => {
         const nextHeadersModule = await import("next/headers");
         const headersList = await nextHeadersModule.headers();

--- a/app/services/user-service.ts
+++ b/app/services/user-service.ts
@@ -1,19 +1,13 @@
-import { createAuthClient } from "@taimei-code/auth-client";
 import { Effect } from "effect";
 import { Email } from "@/app/domain/email";
+import { authClient } from "@/lib/auth/client";
 import { UserNotFound, UserServiceError } from "./user-errors";
-
-const authServiceUrl = process.env.AUTH_SERVICE_URL || "http://localhost:3100";
-const serviceKey = process.env.AUTH_SERVICE_KEY;
 
 export class UserService extends Effect.Service<UserService>()(
   "services/UserService",
   {
     effect: Effect.gen(function* () {
-      const { userService } = createAuthClient({
-        baseUrl: `${authServiceUrl}/rpc`,
-        serviceKey,
-      });
+      const { userService } = authClient;
 
       return {
         existsByEmail: (email: Email) =>

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -1,0 +1,10 @@
+// taimei-auth SDK の単一 instance を提供する module-singleton。接続先の単一情報源を保証する。
+// 経緯は ADR-005 参照 (plans/taimei/ADR-005-auth-service-pattern-unification.md)。
+//
+// server-only ガードは config.ts に集約し、ここから import するだけで連鎖的に効く。
+// 注意: config.ts の `import "server-only"` を消す、または `authClientConfig` を別経路で
+// inline 再定義して `./config` 経由を回避すると、client.ts のガードも同時に消える依存関係。
+import { createAuthClient } from "@taimei-code/auth-client";
+import { authClientConfig } from "./config";
+
+export const authClient = createAuthClient(authClientConfig);

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,0 +1,16 @@
+// auth-client SDK の接続設定の単一情報源。process.env はこのモジュールでのみ直読みする。
+// 経緯は ADR-005 参照 (plans/taimei/ADR-005-auth-service-pattern-unification.md)。
+import "server-only";
+
+// fallback 値はローカル開発用 (compose 経由で taimei-auth が port 3100 で起動する前提)。
+// 本番では Vercel env で必ず注入される運用になっており、未注入時は CI / Vercel 側の env 検証で
+// 弾かれるため fail-fast せず fallback を許容する。
+// FIXME(ADR-005 Phase 2): zod schema で起動時検証を入れ、prod での silent fallback を構造的に防ぐ。
+//   serviceKey が undefined のまま SDK に渡る現状の挙動も、Phase 2 で必須化判定とともに見直す。
+const authServiceUrl = process.env.AUTH_SERVICE_URL || "http://localhost:3100";
+const serviceKey = process.env.AUTH_SERVICE_KEY;
+
+export const authClientConfig = {
+  baseUrl: `${authServiceUrl}/rpc`,
+  serviceKey,
+} as const;


### PR DESCRIPTION
## やったこと

`taimei-auth` SDK の接続設定 (env 直読み) と SDK client インスタンス生成を `lib/auth/{config,client}.ts` に集約。
3 ファイル (auth-guard.ts / auth-service.ts / user-service.ts) で完全重複していた `process.env.AUTH_SERVICE_X` 読み出しと `createAuthClient(...)` 呼出を 1 箇所に圧縮。
SDK の利用者は `import { authClient } from "@/lib/auth/client"` のみ。

## なぜやるのか

3 ファイル中 1 ファイルだけ baseUrl 構成や fallback 値を変更しても TS が通る暗黙の共通結合を構造的に防ぐ。
将来 env 追加 (TLS / tracing / rate limit 設定) や接続先変更が `lib/auth/config.ts` 1 箇所で完結する。
ADR-005 (`plans/taimei/ADR-005-auth-service-pattern-unification.md`) Phase 1 として計画。

## 動作確認結果

- `bun tsc --noEmit` (taimei 全体) エラー 0
- `bun biome check app lib` 122 ファイル pass
- ADR-005 完了判定 1: `grep "process.env.AUTH_SERVICE" app lib --include="*.ts"` → `lib/auth/config.ts` の **1 箇所のみ**
- ADR-005 完了判定 2: `grep "createAuthClient(" app lib --include="*.ts"` → `lib/auth/client.ts` の **1 箇所のみ**
- ADR-004 維持: `grep "better-auth" app proxy.ts components` → 0 件