### PR TITLE
refactor(auth): 動的 import を CookieReader Effect.Service に置換 (ADR-005 Phase 2)

### DIFF
--- a/app/services/__tests__/cookie-reader-service.test.ts
+++ b/app/services/__tests__/cookie-reader-service.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { describe } from "vitest";
+import { CookieReader } from "../cookie-reader-service";
+
+// ADR-005 Phase 2: CookieReader.Custom バリアントの単体テスト。
+// Live バリアントは Next.js の next/headers に依存するため、ここではテストせず
+// Phase 2.5 で AuthClient.Mock と組み合わせた auth-service.ts 統合テストでカバーする。
+
+describe("CookieReader", () => {
+  describe("Custom", () => {
+    it.effect("指定された session token をそのまま返す", () =>
+      Effect.gen(function* () {
+        const reader = yield* CookieReader;
+        const result = yield* reader.readSessionToken;
+        expect(result).toBe("test-token");
+      }).pipe(Effect.provide(CookieReader.Custom("test-token"))),
+    );
+
+    it.effect("undefined を渡すと undefined を返す (未認証分岐の網羅用)", () =>
+      Effect.gen(function* () {
+        const reader = yield* CookieReader;
+        const result = yield* reader.readSessionToken;
+        expect(result).toBeUndefined();
+      }).pipe(Effect.provide(CookieReader.Custom(undefined))),
+    );
+  });
+});

--- a/app/services/auth-service.ts
+++ b/app/services/auth-service.ts
@@ -1,4 +1,3 @@
-import { extractSessionTokenFromCookieHeader } from "@taimei-code/auth-client";
 import { Effect } from "effect";
 import { Email } from "@/app/domain/email";
 import { authClient } from "@/lib/auth/client";
@@ -8,70 +7,69 @@ import {
   SessionError,
   SignOutError,
 } from "./auth-errors";
+import type { CookieReadError } from "./cookie-reader-errors";
+import { CookieReader } from "./cookie-reader-service";
 
 export class AuthService extends Effect.Service<AuthService>()(
   "services/AuthService",
   {
     effect: Effect.gen(function* () {
       const { authService } = authClient;
+      const cookieReader = yield* CookieReader;
 
-      // next/headers は Server Component / Server Action 文脈外で import すると build error になるため、
-      // try callback まで評価を遅延する目的で動的 import を使う。ES module キャッシュが効くので
-      // 2 回目以降のオーバーヘッドはない。
-      // FIXME(ADR-005 Phase 2): auth-guard.ts は SDK helper (getSessionTokenFromCookieStore) 経由、
-      //   ここは生 cookie ヘッダ parse 経由と 2 系統に分裂している。CookieReader Effect.Service として
-      //   抽出し両者を統一する。新規 Service でこの動的 import パターンを真似しないこと。
-      const readSessionToken = async (): Promise<string | undefined> => {
-        const nextHeadersModule = await import("next/headers");
-        const headersList = await nextHeadersModule.headers();
-        return extractSessionTokenFromCookieHeader(
-          headersList.get("cookie") || "",
+      // CookieReadError を呼出側のエラー型 (SessionError / SignOutError 等) に wrap して
+      // 消費側 (Server Action) のエラーハンドリングを増やさない。
+      // toError の引数は CookieReadError として型付け、cause chain を呼出側で型安全に辿れるようにする。
+      const readToken = <E>(toError: (cause: CookieReadError) => E) =>
+        cookieReader.readSessionToken.pipe(
+          Effect.catchTag("CookieReadError", (e) => Effect.fail(toError(e))),
         );
-      };
 
       return {
         getSession: () =>
-          Effect.tryPromise({
-            try: async () => {
-              const token = await readSessionToken();
+          Effect.gen(function* () {
+            const token = yield* readToken(
+              (cause) => new SessionError({ cause }),
+            );
 
-              if (!token) return null;
+            if (!token) return null;
 
-              const result = await authService.verifySession({
-                sessionToken: token,
-              });
+            const result = yield* Effect.tryPromise({
+              try: () => authService.verifySession({ sessionToken: token }),
+              catch: (e) => new SessionError({ cause: e }),
+            });
 
-              if (!result.user || !result.session) return null;
+            if (!result.user || !result.session) return null;
 
-              return {
-                user: {
-                  id: result.user.id,
-                  name: result.user.name,
-                  email: result.user.email,
-                  emailVerified: result.user.emailVerified,
-                  image: result.user.image ?? null,
-                  createdAt: new Date(result.user.createdAt),
-                  updatedAt: new Date(result.user.updatedAt),
-                },
-                session: {
-                  id: result.session.id,
-                  expiresAt: new Date(result.session.expiresAt),
-                },
-              };
-            },
-            catch: (e) => new SessionError({ cause: e }),
+            return {
+              user: {
+                id: result.user.id,
+                name: result.user.name,
+                email: result.user.email,
+                emailVerified: result.user.emailVerified,
+                image: result.user.image ?? null,
+                createdAt: new Date(result.user.createdAt),
+                updatedAt: new Date(result.user.updatedAt),
+              },
+              session: {
+                id: result.session.id,
+                expiresAt: new Date(result.session.expiresAt),
+              },
+            };
           }),
 
         signOut: () =>
-          Effect.tryPromise({
-            try: async () => {
-              const token = await readSessionToken();
+          Effect.gen(function* () {
+            const token = yield* readToken(
+              (cause) => new SignOutError({ cause }),
+            );
 
-              if (token) {
-                await authService.signOut({ sessionToken: token });
-              }
-            },
-            catch: (e) => new SignOutError({ cause: e }),
+            if (token) {
+              yield* Effect.tryPromise({
+                try: () => authService.signOut({ sessionToken: token }),
+                catch: (e) => new SignOutError({ cause: e }),
+              });
+            }
           }),
 
         sendMagicLink: (email: Email, callbackURL: string) =>

--- a/app/services/cookie-reader-errors.ts
+++ b/app/services/cookie-reader-errors.ts
@@ -1,0 +1,8 @@
+import { Data } from "effect";
+
+// 動的 import("next/headers") が Server Component / Server Action 文脈外で呼ばれた場合の throw を捕捉する。
+// Effect.promise は never-fail 前提で throw を Defect 化するため、effect-patterns.md「try-catch 禁止 /
+// TaggedError._tag で分岐」原則に従い Effect.tryPromise + TaggedError 必須。
+export class CookieReadError extends Data.TaggedError("CookieReadError")<{
+  cause: unknown;
+}> {}

--- a/app/services/cookie-reader-service.ts
+++ b/app/services/cookie-reader-service.ts
@@ -1,0 +1,42 @@
+// Server Component / Server Action 文脈で session cookie token を取り出す責務の Effect.Service。
+// 動的 import("next/headers") を Adapter 内部に閉じ込め、AuthService から Next.js 依存を切り離す。
+// 経緯は ADR-005 Phase 2 参照 (plans/taimei/ADR-005-auth-service-pattern-unification.md)。
+import "server-only";
+import { extractSessionTokenFromCookieHeader } from "@taimei-code/auth-client";
+import { Effect, Layer } from "effect";
+import { CookieReadError } from "./cookie-reader-errors";
+
+export class CookieReader extends Effect.Service<CookieReader>()(
+  "services/CookieReader",
+  {
+    effect: Effect.gen(function* () {
+      return {
+        // 動的 import を使う理由: next/headers を静的 import すると、(a) Server Component / Server
+        // Action 文脈外で評価されると build error、(b) vitest 単体実行で next/headers が解決失敗、
+        // の 2 つの問題がある。try callback まで評価を遅延することで両方回避。
+        // ES module キャッシュが効くので 2 回目以降のオーバーヘッドはない。
+        readSessionToken: Effect.tryPromise({
+          try: async () => {
+            const nextHeadersModule = await import("next/headers");
+            const headersList = await nextHeadersModule.headers();
+            return extractSessionTokenFromCookieHeader(
+              headersList.get("cookie") || "",
+            );
+          },
+          catch: (e) => new CookieReadError({ cause: e }),
+        }),
+      } as const;
+    }),
+  },
+) {
+  // テスト用 Layer。null / non-null 分岐の両方を切り替える必要があるため Custom 形式
+  // (固定値 1 種では `getSession` の「token あり/なし」分岐網羅不可、ADR-005 DA9 参照)。
+  //
+  // 実装ノート: Effect.Service は内部で `_tag` を保持するため、`Layer.succeed` には plain object
+  // ではなく `new this({...})` で instance 化したものを渡す必要がある。
+  static Custom = (sessionToken: string | undefined) =>
+    Layer.succeed(
+      this,
+      new this({ readSessionToken: Effect.succeed(sessionToken) }),
+    );
+}

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -2,6 +2,7 @@ import { Effect, Layer, ManagedRuntime } from "effect";
 import { PgDrizzleLive } from "../layers/lives/pg_drizzle_live";
 import { AccountValidationService } from "./account-validation-service";
 import { AuthService } from "./auth-service";
+import { CookieReader } from "./cookie-reader-service";
 import { CustomerService } from "./customer-service";
 import { DashboardService } from "./dashboard-service";
 import { IdGenerator } from "./id-generator-service";
@@ -24,6 +25,8 @@ export {
   UserNotFoundError,
 } from "./auth-errors";
 export { AuthService } from "./auth-service";
+// CookieReader / CookieReadError は AuthService の内部依存として非公開
+// (Layer 配線でのみ使用、外部は AuthService の API のみを利用する)。
 export { CustomerServiceError } from "./customer-errors";
 export { CustomerService } from "./customer-service";
 export { DashboardServiceError } from "./dashboard-errors";
@@ -57,7 +60,8 @@ export { UserService } from "./user-service";
 
 // すべてのサービスの依存関係を一箇所で解決するため Layer.mergeAll で統合
 // Effect.Service は .Default、Effect.Tag は .Live を使用
-// AuthService と UserService は ConnectRPC クライアントを内部で生成するため PgDrizzleLive 不要
+// AuthService / UserService は ConnectRPC クライアント (lib/auth/client.ts の singleton) を使うため
+// PgDrizzleLive 不要。AuthService は Phase 2 で CookieReader.Default を別途 provide する (下記参照)。
 const UserServiceLive = UserService.Default;
 
 export const Live = Layer.mergeAll(
@@ -71,7 +75,7 @@ export const Live = Layer.mergeAll(
   InvoiceService.Default.pipe(Layer.provide(PgDrizzleLive)),
   CustomerService.Default.pipe(Layer.provide(PgDrizzleLive)),
   AccountValidationService.Default.pipe(Layer.provide(UserServiceLive)),
-  AuthService.Default,
+  AuthService.Default.pipe(Layer.provide(CookieReader.Default)),
 );
 
 // Next.js の Server Actions から Effect を実行するため、


### PR DESCRIPTION
## やったこと

`auth-service.ts` 内の動的 `import("next/headers")` を `CookieReader` Effect.Service に切り出した。
SDK の動的 import を Adapter 内部に閉じ込め、`AuthService` は `yield* CookieReader` で token を取得する形に統一。
`CookieReadError` TaggedError を新設し、`Effect.tryPromise` で動的 import の失敗を型表現。

## なぜやるのか

`auth-service.ts` の動的 import は (a) Effect-TS の Service Pattern (effect-patterns.md) 違反、(b) Server Component 文脈外で評価されると build error、(c) vitest 単体実行で `next/headers` が解決失敗、と複数の制約を抱えていた。
`Effect.Service` 化で動的 import を Adapter に閉じ込め、`AuthService` の依存方向が型レベルで明示される。
ADR-005 (`plans/taimei/ADR-005-auth-service-pattern-unification.md`) Phase 2 として計画。

## 動作確認結果

- `bun tsc --noEmit` (taimei 全体) エラー 0
- `bun biome check` 5 ファイル pass
- `bun vitest run app/services/__tests__/cookie-reader-service` 2 pass / 0 fail
- `bun vitest run __tests__/auth-guard` 4 pass (regression なし)
- ADR-005 完了判定: `grep 'import("next/headers")' app/services/auth-service.ts` → **0 件**
- Phase 1 維持: `grep "process.env.AUTH_SERVICE"` 1 箇所 / `grep "createAuthClient("` 1 箇所
- ADR-004 維持: `grep "better-auth"` 0 件

## レビューしてほしい観点

`auth-guard.ts` は SDK API 制約 (DA7) で callback DI 維持、2 経路併存は Phase 3 で解消候補とした判断が妥当か。`getSession`/`signOut` の RPC 結果分岐網羅テストは authClient の Effect.Service 化が前提のため Phase 2.5 に繰越 (DA9)。