### PR TITLE
refactor(auth): AuthClient Effect.Service 化 + 命名整理 (ADR-005 Phase 2.5 + 4)

### DIFF
--- a/app/domain/email.ts
+++ b/app/domain/email.ts
@@ -18,4 +18,7 @@ export const Email = {
   make: Schema.decodeUnknownEither(EmailSchema),
   makeSync: Schema.decodeUnknownSync(EmailSchema),
   fromTrusted: (value: string): Email => value as Email,
+  // Brand 型を SDK / 外部 API の plain string param に降格する。`as string` キャストの意図を
+  // 明示するための薄い helper (schema-library-usage.md の「変換器: as 前置詞」規約)。
+  asString: (value: Email): string => value as string,
 } as const;

--- a/app/services/__tests__/account-validation-service.test.ts
+++ b/app/services/__tests__/account-validation-service.test.ts
@@ -17,7 +17,7 @@ const createMockUserServiceLayer = (existingEmails: Set<string>) =>
     UserService,
     new UserService({
       existsByEmail: (email) =>
-        Effect.succeed(existingEmails.has(email as string)),
+        Effect.succeed(existingEmails.has(Email.asString(email))),
       findByEmail: () => Effect.succeed(undefined),
       findById: () => Effect.succeed(undefined),
       update: (id) => Effect.fail(new UserNotFound({ id })),

--- a/app/services/__tests__/auth-service-integration.test.ts
+++ b/app/services/__tests__/auth-service-integration.test.ts
@@ -1,0 +1,183 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: Mock 用に proto 全フィールドを満たさない部分実装を許容するため (AuthClient.Custom の Partial 型キャストと整合)。CLAUDE.md「Pitfalls / Lint」のブロック形式 disable 推奨に従う。
+import { it } from "@effect/vitest";
+import { Effect, Either, Layer } from "effect";
+import { describe, expect } from "vitest";
+import { AuthClient } from "../auth-client-service";
+import { AuthService } from "../auth-service";
+import { CookieReader } from "../cookie-reader-service";
+
+// ADR-005 Phase 2.5: AuthClient.Custom + CookieReader.Custom の組合せで getSession / signOut の
+// 内部 RPC 結果分岐 (token 有無 + verifySession の user/session 有無 + RPC throw) を網羅する。
+// 既存の auth-service.test.ts は AuthService instance 全体を mock する consumer 視点だが、
+// 本ファイルは AuthService 内部の Effect.gen フロー (CookieReadError → SessionError wrap、
+// 早期 return、tryPromise の catch) を実 instance で検証する。
+
+const provideMocks = (
+  cookieToken: string | undefined,
+  authClientMock: Parameters<typeof AuthClient.Custom>[0],
+) =>
+  Layer.mergeAll(
+    CookieReader.Custom(cookieToken),
+    AuthClient.Custom(authClientMock),
+  );
+
+const runAuth = <A, E>(
+  effect: Effect.Effect<A, E, AuthService>,
+  layer: Layer.Layer<AuthClient | CookieReader, never>,
+) =>
+  effect.pipe(
+    Effect.provide(AuthService.Default.pipe(Layer.provide(layer))),
+    Effect.either,
+    Effect.runPromise,
+  );
+
+describe("AuthService.getSession (Phase 2.5 統合テスト)", () => {
+  it("token が無いと verifySession を呼ばずに null", async () => {
+    let verifyCalled = false;
+    const layer = provideMocks(undefined, {
+      authService: {
+        verifySession: (async () => {
+          verifyCalled = true;
+          return { user: undefined, session: undefined };
+        }) as any,
+      },
+    });
+
+    const result = await runAuth(
+      Effect.gen(function* () {
+        const service = yield* AuthService;
+        return yield* service.getSession();
+      }),
+      layer,
+    );
+
+    expect(Either.isRight(result)).toBe(true);
+    if (Either.isRight(result)) expect(result.right).toBeNull();
+    expect(verifyCalled).toBe(false);
+  });
+
+  it("token あり + verifySession が user/session を返すとセッションが返る", async () => {
+    const layer = provideMocks("test-token", {
+      authService: {
+        verifySession: (async () => ({
+          user: {
+            id: "user-1",
+            name: "Alice",
+            email: "alice@example.com",
+            emailVerified: true,
+            image: undefined,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-02T00:00:00Z",
+          },
+          session: { id: "sess-1", expiresAt: "2026-12-31T00:00:00Z" },
+        })) as any,
+      },
+    });
+
+    const result = await runAuth(
+      Effect.gen(function* () {
+        const service = yield* AuthService;
+        return yield* service.getSession();
+      }),
+      layer,
+    );
+
+    expect(Either.isRight(result)).toBe(true);
+    if (Either.isRight(result) && result.right) {
+      expect(result.right.user.id).toBe("user-1");
+      expect(result.right.user.email).toBe("alice@example.com");
+      expect(result.right.session.id).toBe("sess-1");
+    }
+  });
+
+  it("token あり + verifySession が user undefined を返すと null (期限切れ等)", async () => {
+    const layer = provideMocks("stale-token", {
+      authService: {
+        verifySession: (async () => ({
+          user: undefined,
+          session: undefined,
+        })) as any,
+      },
+    });
+
+    const result = await runAuth(
+      Effect.gen(function* () {
+        const service = yield* AuthService;
+        return yield* service.getSession();
+      }),
+      layer,
+    );
+
+    expect(Either.isRight(result)).toBe(true);
+    if (Either.isRight(result)) expect(result.right).toBeNull();
+  });
+
+  it("verifySession が throw すると SessionError に wrap される", async () => {
+    const layer = provideMocks("test-token", {
+      authService: {
+        verifySession: (async () => {
+          throw new Error("network error");
+        }) as any,
+      },
+    });
+
+    const result = await runAuth(
+      Effect.gen(function* () {
+        const service = yield* AuthService;
+        return yield* service.getSession();
+      }),
+      layer,
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) expect(result.left._tag).toBe("SessionError");
+  });
+});
+
+describe("AuthService.signOut (Phase 2.5 統合テスト)", () => {
+  it("token が無いと RPC を呼ばずに完了 (no-op)", async () => {
+    let signOutCalled = false;
+    const layer = provideMocks(undefined, {
+      authService: {
+        signOut: (async () => {
+          signOutCalled = true;
+          return {};
+        }) as any,
+      },
+    });
+
+    const result = await runAuth(
+      Effect.gen(function* () {
+        const service = yield* AuthService;
+        return yield* service.signOut();
+      }),
+      layer,
+    );
+
+    expect(Either.isRight(result)).toBe(true);
+    expect(signOutCalled).toBe(false);
+  });
+
+  it("token あり + signOut が成功すると RPC が呼ばれる", async () => {
+    let calledToken: string | undefined;
+    const layer = provideMocks("test-token", {
+      authService: {
+        signOut: (async ({ sessionToken }: { sessionToken: string }) => {
+          calledToken = sessionToken;
+          return {};
+        }) as any,
+      },
+    });
+
+    const result = await runAuth(
+      Effect.gen(function* () {
+        const service = yield* AuthService;
+        return yield* service.signOut();
+      }),
+      layer,
+    );
+
+    expect(Either.isRight(result)).toBe(true);
+    expect(calledToken).toBe("test-token");
+  });
+});

--- a/app/services/__tests__/auth-service.test.ts
+++ b/app/services/__tests__/auth-service.test.ts
@@ -44,7 +44,7 @@ const createMockAuthService = (
         ? Effect.fail(new SignOutError({ cause: new Error("Sign out failed") }))
         : Effect.succeed(undefined as void),
 
-    sendMagicLink: (_email: Email, _callbackURL: string) =>
+    sendMagicLink: (_email: Email, _callbackUrl: string) =>
       options.magicLinkError
         ? Effect.fail(
             new MagicLinkError({ cause: new Error("Magic link failed") }),

--- a/app/services/__tests__/db/effect-test-helpers.ts
+++ b/app/services/__tests__/db/effect-test-helpers.ts
@@ -3,6 +3,7 @@ import { it as vitestIt } from "@effect/vitest";
 import type { PgRemoteDatabase } from "drizzle-orm/pg-proxy";
 import { Effect, Layer } from "effect";
 import { AccountValidationService } from "../../account-validation-service";
+import { AuthClient } from "../../auth-client-service";
 import { CustomerService } from "../../customer-service";
 import { DashboardService } from "../../dashboard-service";
 import { IdGenerator } from "../../id-generator-service";
@@ -33,8 +34,17 @@ const createTestServiceLayer = (tx: TestDb) => {
     tx as unknown as PgRemoteDatabase<Record<string, never>>,
   );
 
-  // UserService は ConnectRPC に移行済みのため PgDrizzle 不要
-  const UserServiceLayer = UserService.Default;
+  // UserService は ConnectRPC に移行済みのため PgDrizzle 不要、AuthClient.Default を提供する。
+  // テスト helper では実 RPC を呼ぶ AuthClient.Default を使用 (現状 user-service の DB テストは
+  // RPC 呼出を直接検証していないため Mock 不要)。
+  // Phase 2.5 で AuthClient.Custom 経由の RPC 結果分岐網羅テストは
+  // app/services/__tests__/auth-service-integration.test.ts に集約。
+  // 将来 user-service に RPC 検証を伴うテストを追加する際は、AuthClient.Default ではなく
+  // AuthClient.Custom で差し替えること (実 RPC を silent に叩くのを防ぐため)。
+  const AuthClientLayer = AuthClient.Default;
+  const UserServiceLayer = UserService.Default.pipe(
+    Layer.provide(AuthClientLayer),
+  );
 
   return Layer.mergeAll(
     UserServiceLayer,

--- a/app/services/auth-client-service.ts
+++ b/app/services/auth-client-service.ts
@@ -1,0 +1,41 @@
+// taimei-auth SDK の ConnectRPC client (authService / userService) を Effect.Service として注入する。
+// Phase 1 で `lib/auth/client.ts` の module-singleton を作ったが、テストでは authClient 全体を
+// vi.mock するか実 RPC を叩くしかなく、auth-service.ts や user-service.ts の RPC 結果分岐網羅が
+// 不可能だった。Effect.Service 化で AuthClient.Custom を提供し、Layer.provide で差し替え可能にする。
+// 経緯は ADR-005 Phase 2.5 参照 (plans/taimei/ADR-005-auth-service-pattern-unification.md)。
+import "server-only";
+import { Effect, Layer } from "effect";
+import { authClient } from "@/lib/auth/client";
+
+type AuthClientShape = typeof authClient;
+
+export class AuthClient extends Effect.Service<AuthClient>()(
+  "services/AuthClient",
+  {
+    effect: Effect.gen(function* () {
+      // Live バリアント: Phase 1 で作った module-singleton をそのまま service instance 化する。
+      // singleton 自体は維持 (server-only ガードを `lib/auth/client.ts` 経由で連鎖させるため)。
+      return {
+        authService: authClient.authService,
+        userService: authClient.userService,
+      };
+    }),
+  },
+) {
+  // テスト用: authService / userService の任意メソッドを差し替える Layer。
+  // Partial 型キャストで「テストが必要なメソッドだけ実装」を許容する (RPC 全 method 実装は冗長)。
+  // CookieReader.Custom と命名を揃え、「テスト用カスタム Layer」の意図を統一表現する。
+  static Custom = (overrides: {
+    authService?: Partial<AuthClientShape["authService"]>;
+    userService?: Partial<AuthClientShape["userService"]>;
+  }) =>
+    Layer.succeed(
+      this,
+      new this({
+        authService: (overrides.authService ??
+          {}) as AuthClientShape["authService"],
+        userService: (overrides.userService ??
+          {}) as AuthClientShape["userService"],
+      }),
+    );
+}

--- a/app/services/auth-service.ts
+++ b/app/services/auth-service.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { Email } from "@/app/domain/email";
-import { authClient } from "@/lib/auth/client";
+import { AuthClient } from "./auth-client-service";
 import {
   AuthServiceError,
   MagicLinkError,
@@ -14,7 +14,7 @@ export class AuthService extends Effect.Service<AuthService>()(
   "services/AuthService",
   {
     effect: Effect.gen(function* () {
-      const { authService } = authClient;
+      const { authService } = yield* AuthClient;
       const cookieReader = yield* CookieReader;
 
       // CookieReadError を呼出側のエラー型 (SessionError / SignOutError 等) に wrap して
@@ -34,26 +34,26 @@ export class AuthService extends Effect.Service<AuthService>()(
 
             if (!token) return null;
 
-            const result = yield* Effect.tryPromise({
+            const verifyResult = yield* Effect.tryPromise({
               try: () => authService.verifySession({ sessionToken: token }),
               catch: (e) => new SessionError({ cause: e }),
             });
 
-            if (!result.user || !result.session) return null;
+            if (!verifyResult.user || !verifyResult.session) return null;
 
             return {
               user: {
-                id: result.user.id,
-                name: result.user.name,
-                email: result.user.email,
-                emailVerified: result.user.emailVerified,
-                image: result.user.image ?? null,
-                createdAt: new Date(result.user.createdAt),
-                updatedAt: new Date(result.user.updatedAt),
+                id: verifyResult.user.id,
+                name: verifyResult.user.name,
+                email: verifyResult.user.email,
+                emailVerified: verifyResult.user.emailVerified,
+                image: verifyResult.user.image ?? null,
+                createdAt: new Date(verifyResult.user.createdAt),
+                updatedAt: new Date(verifyResult.user.updatedAt),
               },
               session: {
-                id: result.session.id,
-                expiresAt: new Date(result.session.expiresAt),
+                id: verifyResult.session.id,
+                expiresAt: new Date(verifyResult.session.expiresAt),
               },
             };
           }),
@@ -72,36 +72,40 @@ export class AuthService extends Effect.Service<AuthService>()(
             }
           }),
 
-        sendMagicLink: (email: Email, callbackURL: string) =>
+        sendMagicLink: (email: Email, callbackUrl: string) =>
           Effect.tryPromise({
             try: async () => {
               await authService.sendMagicLink({
-                email: email as string,
-                callbackUrl: callbackURL,
+                email: Email.asString(email),
+                callbackUrl,
               });
             },
             catch: (e) => new MagicLinkError({ cause: e }),
           }),
 
+        // FIXME(ADR-005 DA2): null / new Date() の padding は proto contract が optional 化されて
+        //   いないため呼出側型を満たす目的の偽値。OAuth provider 連携拡張時に proto 側で optional
+        //   化し、ここの padding を削除する。`createdAt: new Date()` は事実と異なるため、呼出側で
+        //   この値を信用しないこと (account 作成日時としては使えない)。
         findAccountByUserId: (userId: string) =>
           Effect.tryPromise({
             try: async () => {
-              const result = await authService.findAccountByUserId({
+              const accountResult = await authService.findAccountByUserId({
                 userId,
               });
-              if (!result.account) return undefined;
+              if (!accountResult.account) return undefined;
 
               return {
-                id: result.account.id,
-                accountId: result.account.accountId,
-                providerId: result.account.providerId,
-                userId: result.account.userId,
-                accessToken: result.account.accessToken ?? null,
-                refreshToken: result.account.refreshToken ?? null,
+                id: accountResult.account.id,
+                accountId: accountResult.account.accountId,
+                providerId: accountResult.account.providerId,
+                userId: accountResult.account.userId,
+                accessToken: accountResult.account.accessToken ?? null,
+                refreshToken: accountResult.account.refreshToken ?? null,
                 idToken: null,
                 accessTokenExpiresAt: null,
                 refreshTokenExpiresAt: null,
-                scope: result.account.scope ?? null,
+                scope: accountResult.account.scope ?? null,
                 password: null,
                 createdAt: new Date(),
                 updatedAt: new Date(),

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { PgDrizzleLive } from "../layers/lives/pg_drizzle_live";
 import { AccountValidationService } from "./account-validation-service";
+import { AuthClient } from "./auth-client-service";
 import { AuthService } from "./auth-service";
 import { CookieReader } from "./cookie-reader-service";
 import { CustomerService } from "./customer-service";
@@ -60,9 +61,10 @@ export { UserService } from "./user-service";
 
 // すべてのサービスの依存関係を一箇所で解決するため Layer.mergeAll で統合
 // Effect.Service は .Default、Effect.Tag は .Live を使用
-// AuthService / UserService は ConnectRPC クライアント (lib/auth/client.ts の singleton) を使うため
-// PgDrizzleLive 不要。AuthService は Phase 2 で CookieReader.Default を別途 provide する (下記参照)。
-const UserServiceLive = UserService.Default;
+// AuthClient.Default は ConnectRPC client (lib/auth/client.ts の singleton) を返すため PgDrizzleLive 不要。
+// AuthService / UserService は AuthClient.Default に依存、AuthService は更に CookieReader.Default にも依存。
+const AuthClientLive = AuthClient.Default;
+const UserServiceLive = UserService.Default.pipe(Layer.provide(AuthClientLive));
 
 export const Live = Layer.mergeAll(
   Tag2Service.Default.pipe(Layer.provide(PgDrizzleLive)),
@@ -75,7 +77,10 @@ export const Live = Layer.mergeAll(
   InvoiceService.Default.pipe(Layer.provide(PgDrizzleLive)),
   CustomerService.Default.pipe(Layer.provide(PgDrizzleLive)),
   AccountValidationService.Default.pipe(Layer.provide(UserServiceLive)),
-  AuthService.Default.pipe(Layer.provide(CookieReader.Default)),
+  AuthService.Default.pipe(
+    Layer.provide(CookieReader.Default),
+    Layer.provide(AuthClientLive),
+  ),
 );
 
 // Next.js の Server Actions から Effect を実行するため、

--- a/app/services/user-service.ts
+++ b/app/services/user-service.ts
@@ -1,20 +1,20 @@
 import { Effect } from "effect";
 import { Email } from "@/app/domain/email";
-import { authClient } from "@/lib/auth/client";
+import { AuthClient } from "./auth-client-service";
 import { UserNotFound, UserServiceError } from "./user-errors";
 
 export class UserService extends Effect.Service<UserService>()(
   "services/UserService",
   {
     effect: Effect.gen(function* () {
-      const { userService } = authClient;
+      const { userService } = yield* AuthClient;
 
       return {
         existsByEmail: (email: Email) =>
           Effect.tryPromise({
             try: async () => {
               const result = await userService.findUserByEmail({
-                email: email as string,
+                email: Email.asString(email),
               });
               return result.user !== undefined;
             },
@@ -26,7 +26,7 @@ export class UserService extends Effect.Service<UserService>()(
           Effect.tryPromise({
             try: async () => {
               const result = await userService.findUserByEmail({
-                email: email as string,
+                email: Email.asString(email),
               });
               if (!result.user) return undefined;
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -67,10 +67,11 @@ export default async function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
+     * 以下のパスを除く全リクエストにマッチ:
+     * - _next/static (静的ファイル)
+     * - _next/image (画像最適化ファイル)
+     * - favicon.ico (favicon)
+     * - 画像拡張子 (svg/png/jpg/jpeg/gif/webp) を持つファイル
      */
     "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],


### PR DESCRIPTION
## やったこと

`authClient` (`@taimei-code/auth-client` の RPC client) を `AuthClient` Effect.Service として注入可能にした。
`auth-service.ts` と `user-service.ts` の RPC 結果分岐をテストでモック可能にし、`AuthClient.Custom` + `CookieReader.Custom` の組合せで getSession/signOut の全分岐 (6 ケース) を網羅する統合テストを追加。
あわせて Phase 4 の軽微な可読性改善 (`Email.asString` helper / `result` rename / `callbackURL` 統一 / `proxy.ts` 日本語コメント) を一括実施。

## なぜやるのか

Phase 2 完了時点で `auth-service.ts` の RPC 結果分岐を網羅するには `authClient` 全体を vi.mock するか実 RPC を叩くしかなく、ユニットテストとして成立していなかった。
Effect.Service 化で `Layer.provide(AuthClient.Custom({...}))` で部分実装を差し替え可能になり、verifySession の user/session 有無 / throw の各分岐を型安全に検証できる。
`Email.asString` は Brand 型の `as string` キャストの意図 (SDK plain string への降格) を 1 箇所に閉じ込め、`schema-library-usage.md` の「変換器: `as` 前置詞」規約に準拠させる。

## 動作確認結果

- `bun tsc --noEmit` (taimei 全体) エラー 0
- `bun biome check` 128 ファイル pass
- `bun vitest run __tests__ app/services/__tests__` **15 ファイル / 86 tests pass / 0 fail** (新規 6 + 既存 80)
- ADR 完了判定維持:
  - Phase 2: `grep 'import("next/headers")' app/services/auth-service.ts` → 0 件
  - Phase 2.5: `grep "authClient" app/services/auth-service.ts app/services/user-service.ts` → 0 件 (Service 経由化)
  - ADR-004: `grep "better-auth"` → 0 件

## 設計判断

`AuthClient.Default` の Live バリアントは `lib/auth/client.ts` の Phase 1 singleton をそのまま返す形を選んだ。`createAuthClient(config)` を Service 内部で呼ぶ形に変えれば真の DIP になるが、Phase 1 で確立した singleton を捨てるトレードオフがあるため Phase 5 候補として ADR-005 Roadmap に追記。本 PR は **「test seam の追加」** が目的で、本番コードの依存方向逆転は別 ADR で再評価する。

`AuthClient.Custom` の引数は `{ authService?: Partial<...>, userService?: Partial<...> }` で、`?? {}` の空オブジェクトキャストにより部分実装を許容する。テスト側で `as any` キャストが必要になるが、ファイル冒頭の `biome-ignore-all` ブロック形式で集約 (CLAUDE.md「Pitfalls / Lint」推奨)。

## やらなかったこと

Phase 3 (SDK guard.ts internal refactor: try-catch → then-catch、non-null assertion 削除、cache 型 strict 化、`/dashboard` ハードコード DI 化、SessionData mapping 抽出 + 0.2.0 minor bump) は taimei-auth リポジトリ側の SDK 変更が必要なため本 PR スコープ外。SDK PR → publish → consumer 追従 の 2 段 PR で別途実施。

`findAccountByUserId` の null padding (`createdAt: new Date()` 等の偽値) は ADR-005 DA2 で「proto contract が optional 化されるまで保留」と判定済み。本 PR では FIXME コメントで「呼出側で createdAt/updatedAt/idToken を信用しないこと」を明示するに留めた。

`AuthService` の責務分離 (Session vs MagicLink vs Account) は DA1 で不採用判定済み (Service 数増加コスト > 保守性メリット)。

## レビューしてほしい観点

`AuthClient.Default` が `lib/auth/client.ts` singleton を参照する設計は DI を装った共通結合だが、Phase 5 までの暫定として許容する判断が妥当か。