### PR TITLE
refactor(auth)!: auth-client 0.5.0 追従 (ADR-007 PR2)

### DIFF
--- a/__tests__/auth-guard.test.ts
+++ b/__tests__/auth-guard.test.ts
@@ -9,18 +9,25 @@ vi.mock("next/headers", () => ({
   cookies: vi.fn(),
 }));
 
-const mockRequireSession = vi.fn();
 const mockGetSession = vi.fn();
 
+// SDK 0.5.0 (ADR-007) で createAuthGuard 戻り値は { getSession } のみ。
+// requireSession は consumer 側 wrapper (`app/lib/auth-guard.ts`) で実装するため
+// mock せず実装ごとテストする (session の有無で redirect が呼ばれることを assert)。
 vi.mock("@taimei-code/auth-client", () => ({
   createAuthClient: () => ({
     authService: { verifySession: vi.fn() },
     userService: {},
   }),
   createAuthGuard: () => ({
-    requireSession: mockRequireSession,
     getSession: mockGetSession,
   }),
+  createServiceKeyInterceptor: vi.fn(() => () => ({})),
+  getSessionToken: vi.fn(),
+}));
+
+vi.mock("@connectrpc/connect-node", () => ({
+  createConnectTransport: vi.fn(() => ({})),
 }));
 
 const mockSession = {
@@ -35,9 +42,7 @@ const mockSession = {
   },
   session: {
     id: "session-id",
-    token: "test-token",
     expiresAt: new Date(Date.now() + 86400000).toISOString(),
-    userId: "user-id",
   },
 };
 
@@ -50,11 +55,9 @@ describe("auth-guard", () => {
     } as any);
   });
 
-  describe("requireSession", () => {
+  describe("requireSession (consumer wrapper)", () => {
     test("未認証の場合、/auth へリダイレクト", async () => {
-      mockRequireSession.mockImplementation(() => {
-        redirect("/auth?callbackUrl=%2Fdashboard");
-      });
+      mockGetSession.mockResolvedValue(null);
 
       const { requireSession } = await import("@/app/lib/auth-guard");
       await requireSession({ returnTo: "/dashboard" });
@@ -63,7 +66,7 @@ describe("auth-guard", () => {
     });
 
     test("認証済みの場合、セッションを返す", async () => {
-      mockRequireSession.mockResolvedValue(mockSession);
+      mockGetSession.mockResolvedValue(mockSession);
 
       const { requireSession } = await import("@/app/lib/auth-guard");
       const result = await requireSession({ returnTo: "/dashboard" });

--- a/app/lib/auth-guard.ts
+++ b/app/lib/auth-guard.ts
@@ -1,9 +1,7 @@
-// クライアントサイドでの誤用を防止（セッション検証はサーバーサイドでのみ安全）
+// `lib/auth/client.ts` 経由で Service Key interceptor 注入済の authClient を import するため、
+// bundle に Service Key が漏れる経路を server-only ガードで完全に閉じる。
 import "server-only";
-import {
-  createAuthGuard,
-  getSessionTokenFromCookieStore,
-} from "@taimei-code/auth-client";
+import { createAuthGuard, getSessionToken } from "@taimei-code/auth-client";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { cache } from "react";
@@ -12,18 +10,27 @@ import { authClient } from "@/lib/auth/client";
 const guard = createAuthGuard({
   client: authClient,
   cache,
-  redirect,
   getSessionToken: async () => {
     const cookieStore = await cookies();
-    return getSessionTokenFromCookieStore(cookieStore);
+    return getSessionToken((name) => cookieStore.get(name)?.value);
   },
 });
 
-// cache() で同一リクエスト内のRPC呼び出しを1回に抑制（layout/page で複数回呼んでも効率的）
-export const requireSession = guard.requireSession;
-
-// requireSession と異なりリダイレクトしない（ルートページ等で認証状態に応じた分岐が必要な場合用）
+// requireSession と異なりリダイレクトしない（ルートページ等で認証状態に応じた分岐が必要な場合用）。
+// cache() で同一リクエスト内の RPC 呼び出しを 1 回に抑制 (layout/page で複数回呼んでも効率的)。
 export const getSession = guard.getSession;
 
 export type Session = Awaited<ReturnType<typeof getSession>>;
 export type VerifiedSession = Exclude<Session, null>;
+
+// SDK 0.5.0 で SDK 側 requireSession は廃止 (ADR-007)。redirect 制御フローと
+// login path 規約 `/auth?callbackUrl=` を consumer 側に集約する。
+export const requireSession = async ({
+  returnTo,
+}: {
+  returnTo: string;
+}): Promise<VerifiedSession> => {
+  const session = await getSession();
+  if (!session) redirect(`/auth?callbackUrl=${encodeURIComponent(returnTo)}`);
+  return session;
+};

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "@react-email/components": "^1.0.2",
         "@sentry/nextjs": "^9",
         "@tailwindcss/forms": "^0.5.7",
-        "@taimei-code/auth-client": "^0.4.0",
+        "@taimei-code/auth-client": "^0.5.0",
         "@vercel/blob": "^1.0.0",
         "autoprefixer": "10.4.19",
         "bcrypt": "^5.1.1",
@@ -848,7 +848,7 @@
 
     "@tailwindcss/forms": ["@tailwindcss/forms@0.5.11", "", { "dependencies": { "mini-svg-data-uri": "^1.2.3" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1" } }, "sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA=="],
 
-    "@taimei-code/auth-client": ["@taimei-code/auth-client@0.4.0", "https://npm.pkg.github.com/download/@taimei-code/auth-client/0.4.0/da493bea7ca5a860b5da89a998bce03e61d86e4a", { "dependencies": { "effect": "^3.19.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.0.0", "@connectrpc/connect": "^2.0.0", "@connectrpc/connect-node": "^2.0.0" } }, "sha512-6ULCUk6al9L22xzuBw9XHknNENOxr9ll+Z8d9ti/czRS9NszPV2yGD8TteUyPqlMaqcpG09/Mxx1N7ljLyMfvQ=="],
+    "@taimei-code/auth-client": ["@taimei-code/auth-client@0.5.0", "https://npm.pkg.github.com/download/@taimei-code/auth-client/0.5.0/55dc9b77fe767b7853ac729e3f89433160059fe6", { "dependencies": { "effect": "^3.19.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.0.0", "@connectrpc/connect": "^2.0.0" } }, "sha512-CWExjjdT8okFj6h7qylLVYRzNwhKxoOXz6y1XF4+Efxjtyd0+iF94puegZOGEQcPPITtypBdl5ZwGMkC2P8ypA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -1,10 +1,27 @@
 // taimei-auth SDK の単一 instance を提供する module-singleton。接続先の単一情報源を保証する。
-// 経緯は ADR-005 参照 (plans/taimei/ADR-005-auth-service-pattern-unification.md)。
+// 経緯は ADR-005 / ADR-007 参照 (plans/taimei/ADR-005, ADR-007)。
 //
 // server-only ガードは config.ts に集約し、ここから import するだけで連鎖的に効く。
 // 注意: config.ts の `import "server-only"` を消す、または `authClientConfig` を別経路で
 // inline 再定義して `./config` 経由を回避すると、client.ts のガードも同時に消える依存関係。
-import { createAuthClient } from "@taimei-code/auth-client";
+import { createConnectTransport } from "@connectrpc/connect-node";
+import {
+  createAuthClient,
+  createServiceKeyInterceptor,
+} from "@taimei-code/auth-client";
 import { authClientConfig } from "./config";
 
-export const authClient = createAuthClient(authClientConfig);
+// Service Key 注入。dev / local 環境では env 未設定で undefined になる (config.ts FIXME 参照)。
+const interceptors = authClientConfig.serviceKey
+  ? [createServiceKeyInterceptor(authClientConfig.serviceKey)]
+  : [];
+
+// Vercel Node runtime 想定で httpVersion 1.1 を指定。Edge / Workers に乗せ替える際は
+// @connectrpc/connect-web に差し替え、httpVersion を省略する (ADR-007 README §3)。
+const transport = createConnectTransport({
+  httpVersion: "1.1",
+  baseUrl: authClientConfig.baseUrl,
+  interceptors,
+});
+
+export const authClient = createAuthClient({ transport });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@react-email/components": "^1.0.2",
     "@sentry/nextjs": "^9",
     "@tailwindcss/forms": "^0.5.7",
-    "@taimei-code/auth-client": "^0.4.0",
+    "@taimei-code/auth-client": "^0.5.0",
     "@vercel/blob": "^1.0.0",
     "autoprefixer": "10.4.19",
     "bcrypt": "^5.1.1",

--- a/proxy.ts
+++ b/proxy.ts
@@ -56,7 +56,7 @@ export default async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  if (!hasAuthCookie(request)) {
+  if (!hasAuthCookie((name) => request.cookies.get(name)?.value)) {
     // 保護ページに未認証アクセス → 元の path に戻すため returnTo は元 pathname を維持。
     return redirectToAuth(`${APP_URL}${pathname}${request.nextUrl.search}`);
   }


### PR DESCRIPTION
## やったこと

SDK 0.5.0 (ADR-007) の framework agnostic 化に追従。SDK から落ちた redirect 制御を consumer wrapper で吸収する。

- package.json: `@taimei-code/auth-client` ^0.4.0 → ^0.5.0
- lib/auth/client.ts: transport を consumer 側で構築 (createConnectTransport + Service Key interceptor)
- app/lib/auth-guard.ts: 旧 SDK `requireSession` 削除、4 行 wrapper で `/auth?callbackUrl=` を組立て
- app/lib/auth-guard.ts: `getSessionToken` を CookieReader lambda で呼び出し
- proxy.ts: `hasAuthCookie` を `(name) => request.cookies.get(name)?.value` lambda 呼出に変更
- __tests__/auth-guard.test.ts: createAuthGuard mock を `{ getSession }` のみに、dead fields (`token`/`userId`) 除去

## なぜやるのか

taimei-auth SDK 0.5.0 で SDK から Next.js / React 依存を完全に剥がす ADR-007 の作業の consumer 側追従。各 RSC ページの `requireSession({ returnTo: "..." })` シグネチャを維持しているため layout / page は touch せず、変更を 6 ファイル ~50 行に閉じる。

## 設計判断

`requireSession` の signature を `{ returnTo }` object 引数で維持し、wrapper を `app/lib/auth-guard.ts` 内に閉じることで `app/dashboard/layout.tsx` / `app/setting/layout.tsx` の `Promise.all([requireSession(...), fetchCurrentUser()])` パターンを無変更にした。redirect 規約 `/auth?callbackUrl=` と login path は consumer 所有 (JIT auth 統合の `.claude/rules/auth-design.md` 規約に整合)。

transport 構築は consumer 側で行う方針 (ADR-007 DA9 で受容)。SDK 側 factory 化 (`createNodeAuthClient` など framework 別 adapter) は DA1 で不採用と確定済。

## やらなかったこと

`auth-guard.ts` を SDK adapter と consumer wrapper の 2 ファイルに分離する refactor は本 PR スコープ外として見送り、Phase X+ 候補に残す。proxy.ts の `AFTER_SIGNIN_URL` 等の SSOT 化も既存コード由来で本 PR は touch しない。

## レビューしてほしい観点

- transport の `httpVersion: "1.1"` hardcode が Vercel Node runtime 想定として妥当か (Edge 移行時に lib/auth/client.ts のみ差替で済む構造か)
- `vi.mock("@connectrpc/connect-node")` で transport stub 化したテストが SDK shape drift を検知できる粒度か

## 動作確認結果

`bun run lint && bunx tsc --noEmit && bun run test:db` 全 86 tests + lint + typecheck pass、`bun run deployable-test` (next build) 成功。
