### PR TITLE
feat(auth)!: @taimei-code/auth-client 0.5 → 1.0 + VerifyResult 対応 (PR-C)

### DIFF
--- a/__tests__/auth-guard.test.ts
+++ b/__tests__/auth-guard.test.ts
@@ -11,9 +11,9 @@ vi.mock("next/headers", () => ({
 
 const mockGetSession = vi.fn();
 
-// SDK 0.5.0 (ADR-007) で createAuthGuard 戻り値は { getSession } のみ。
-// requireSession は consumer 側 wrapper (`app/lib/auth-guard.ts`) で実装するため
-// mock せず実装ごとテストする (session の有無で redirect が呼ばれることを assert)。
+// SDK 1.0.0 (ADR-001 R2) で createAuthGuard().getSession() の戻り型が VerifyResult に変更:
+//   { ok: true; data: SessionData } | { ok: false; reason: Result }
+// auth-guard.ts の thin wrap で { result.ok ? result.data : null } に変換する形を維持。
 vi.mock("@taimei-code/auth-client", () => ({
   createAuthClient: () => ({
     authService: { verifySession: vi.fn() },
@@ -24,13 +24,14 @@ vi.mock("@taimei-code/auth-client", () => ({
   }),
   createServiceKeyInterceptor: vi.fn(() => () => ({})),
   getSessionToken: vi.fn(),
+  Result: { UNSPECIFIED: 0, SESSION_NOT_FOUND: 2 },
 }));
 
 vi.mock("@connectrpc/connect-node", () => ({
   createConnectTransport: vi.fn(() => ({})),
 }));
 
-const mockSession = {
+const mockSessionData = {
   user: {
     id: "user-id",
     name: "Test User",
@@ -43,6 +44,7 @@ const mockSession = {
   session: {
     id: "session-id",
     expiresAt: new Date(Date.now() + 86400000).toISOString(),
+    kind: "user",
   },
 };
 
@@ -57,7 +59,7 @@ describe("auth-guard", () => {
 
   describe("requireSession (consumer wrapper)", () => {
     test("未認証の場合、/auth へリダイレクト", async () => {
-      mockGetSession.mockResolvedValue(null);
+      mockGetSession.mockResolvedValue({ ok: false, reason: 2 });
 
       const { requireSession } = await import("@/app/lib/auth-guard");
       await requireSession({ returnTo: "/dashboard" });
@@ -66,19 +68,19 @@ describe("auth-guard", () => {
     });
 
     test("認証済みの場合、セッションを返す", async () => {
-      mockGetSession.mockResolvedValue(mockSession);
+      mockGetSession.mockResolvedValue({ ok: true, data: mockSessionData });
 
       const { requireSession } = await import("@/app/lib/auth-guard");
       const result = await requireSession({ returnTo: "/dashboard" });
 
       expect(redirect).not.toHaveBeenCalled();
-      expect(result).toEqual(mockSession);
+      expect(result).toEqual(mockSessionData);
     });
   });
 
   describe("getSession", () => {
     test("未認証の場合、null を返す（リダイレクトなし）", async () => {
-      mockGetSession.mockResolvedValue(null);
+      mockGetSession.mockResolvedValue({ ok: false, reason: 2 });
 
       const { getSession } = await import("@/app/lib/auth-guard");
       const result = await getSession();
@@ -88,12 +90,12 @@ describe("auth-guard", () => {
     });
 
     test("認証済みの場合、セッションを返す", async () => {
-      mockGetSession.mockResolvedValue(mockSession);
+      mockGetSession.mockResolvedValue({ ok: true, data: mockSessionData });
 
       const { getSession } = await import("@/app/lib/auth-guard");
       const result = await getSession();
 
-      expect(result).toEqual(mockSession);
+      expect(result).toEqual(mockSessionData);
     });
   });
 });

--- a/app/lib/auth-guard.ts
+++ b/app/lib/auth-guard.ts
@@ -1,7 +1,12 @@
 // `lib/auth/client.ts` 経由で Service Key interceptor 注入済の authClient を import するため、
 // bundle に Service Key が漏れる経路を server-only ガードで完全に閉じる。
 import "server-only";
-import { createAuthGuard, getSessionToken } from "@taimei-code/auth-client";
+import {
+  createAuthGuard,
+  getSessionToken,
+  Result,
+  type SessionData,
+} from "@taimei-code/auth-client";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { cache } from "react";
@@ -16,15 +21,22 @@ const guard = createAuthGuard({
   },
 });
 
-// requireSession と異なりリダイレクトしない（ルートページ等で認証状態に応じた分岐が必要な場合用）。
-// cache() で同一リクエスト内の RPC 呼び出しを 1 回に抑制 (layout/page で複数回呼んでも効率的)。
-export const getSession = guard.getSession;
+// SDK 1.0.0 (ADR-001 R2) で戻り値が VerifyResult discriminated union 化されたため、
+// consumer 側で従来の `if (!session)` パターンを維持するための thin wrap を提供する。
+// reason が REVISION_OUTDATED のときは login URL に hash を付けてユーザーに再ログイン要因を示す
+// (現状は signin_failed への redirect で十分なので未実装、将来の UI 改善余地として残す)。
+export const getSession = async (): Promise<SessionData | null> => {
+  const result = await guard.getSession();
+  if (!result.ok) return null;
+  return result.data;
+};
 
 export type Session = Awaited<ReturnType<typeof getSession>>;
 export type VerifiedSession = Exclude<Session, null>;
 
 // SDK 0.5.0 で SDK 側 requireSession は廃止 (ADR-007)。redirect 制御フローと
 // login path 規約 `/auth?callbackUrl=` を consumer 側に集約する。
+// SDK 1.0.0 で getSession の戻り型が変わったため、上記 thin wrap 経由で従来の null チェックを維持。
 export const requireSession = async ({
   returnTo,
 }: {
@@ -34,3 +46,6 @@ export const requireSession = async ({
   if (!session) redirect(`/auth?callbackUrl=${encodeURIComponent(returnTo)}`);
   return session;
 };
+
+// Result enum を consumer (page 等) でも参照可能にする re-export
+export { Result };

--- a/app/services/__tests__/auth-service-integration.test.ts
+++ b/app/services/__tests__/auth-service-integration.test.ts
@@ -38,7 +38,7 @@ describe("AuthService.getSession (Phase 2.5 統合テスト)", () => {
       authService: {
         verifySession: (async () => {
           verifyCalled = true;
-          return { user: undefined, session: undefined };
+          return { outcome: { case: "error", value: { reason: 2 } } };
         }) as any,
       },
     });
@@ -57,19 +57,30 @@ describe("AuthService.getSession (Phase 2.5 統合テスト)", () => {
   });
 
   it("token あり + verifySession が user/session を返すとセッションが返る", async () => {
+    // ADR-001 R2: VerifySessionResponse は oneof outcome へ変更
     const layer = provideMocks("test-token", {
       authService: {
         verifySession: (async () => ({
-          user: {
-            id: "user-1",
-            name: "Alice",
-            email: "alice@example.com",
-            emailVerified: true,
-            image: undefined,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-02T00:00:00Z",
+          outcome: {
+            case: "ok",
+            value: {
+              user: {
+                id: "user-1",
+                name: "Alice",
+                email: "alice@example.com",
+                emailVerified: true,
+                image: undefined,
+                createdAt: "2026-01-01T00:00:00Z",
+                updatedAt: "2026-01-02T00:00:00Z",
+                revision: 0,
+              },
+              session: {
+                id: "sess-1",
+                expiresAt: "2026-12-31T00:00:00Z",
+                sessionKind: "user",
+              },
+            },
           },
-          session: { id: "sess-1", expiresAt: "2026-12-31T00:00:00Z" },
         })) as any,
       },
     });
@@ -90,12 +101,11 @@ describe("AuthService.getSession (Phase 2.5 統合テスト)", () => {
     }
   });
 
-  it("token あり + verifySession が user undefined を返すと null (期限切れ等)", async () => {
+  it("token あり + verifySession が error outcome を返すと null (期限切れ / REVISION_OUTDATED 等)", async () => {
     const layer = provideMocks("stale-token", {
       authService: {
         verifySession: (async () => ({
-          user: undefined,
-          session: undefined,
+          outcome: { case: "error", value: { reason: 7 } }, // RESULT_REVISION_OUTDATED
         })) as any,
       },
     });

--- a/app/services/auth-service.ts
+++ b/app/services/auth-service.ts
@@ -39,21 +39,28 @@ export class AuthService extends Effect.Service<AuthService>()(
               catch: (e) => new SessionError({ cause: e }),
             });
 
-            if (!verifyResult.user || !verifyResult.session) return null;
+            // ADR-001 R2: VerifySessionResponse は oneof outcome に再設計済。
+            // outcome === "ok" 以外 (error / 未設定) は全て null に集約し、consumer は
+            // SDK の VerifyResult ではなく自前 SessionError でハンドリングする (Effect 層)。
+            if (verifyResult.outcome.case !== "ok") return null;
+            const okValue = verifyResult.outcome.value;
+            const user = okValue.user;
+            const session = okValue.session;
+            if (!user || !session) return null;
 
             return {
               user: {
-                id: verifyResult.user.id,
-                name: verifyResult.user.name,
-                email: verifyResult.user.email,
-                emailVerified: verifyResult.user.emailVerified,
-                image: verifyResult.user.image ?? null,
-                createdAt: new Date(verifyResult.user.createdAt),
-                updatedAt: new Date(verifyResult.user.updatedAt),
+                id: user.id,
+                name: user.name,
+                email: user.email,
+                emailVerified: user.emailVerified,
+                image: user.image ?? null,
+                createdAt: new Date(user.createdAt),
+                updatedAt: new Date(user.updatedAt),
               },
               session: {
-                id: verifyResult.session.id,
-                expiresAt: new Date(verifyResult.session.expiresAt),
+                id: session.id,
+                expiresAt: new Date(session.expiresAt),
               },
             };
           }),

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "@react-email/components": "^1.0.2",
         "@sentry/nextjs": "^9",
         "@tailwindcss/forms": "^0.5.7",
-        "@taimei-code/auth-client": "^0.5.0",
+        "@taimei-code/auth-client": "^1.0.0",
         "@vercel/blob": "^1.0.0",
         "autoprefixer": "10.4.19",
         "bcrypt": "^5.1.1",
@@ -848,7 +848,7 @@
 
     "@tailwindcss/forms": ["@tailwindcss/forms@0.5.11", "", { "dependencies": { "mini-svg-data-uri": "^1.2.3" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1" } }, "sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA=="],
 
-    "@taimei-code/auth-client": ["@taimei-code/auth-client@0.5.0", "https://npm.pkg.github.com/download/@taimei-code/auth-client/0.5.0/55dc9b77fe767b7853ac729e3f89433160059fe6", { "dependencies": { "effect": "^3.19.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.0.0", "@connectrpc/connect": "^2.0.0" } }, "sha512-CWExjjdT8okFj6h7qylLVYRzNwhKxoOXz6y1XF4+Efxjtyd0+iF94puegZOGEQcPPITtypBdl5ZwGMkC2P8ypA=="],
+    "@taimei-code/auth-client": ["@taimei-code/auth-client@1.0.0", "https://npm.pkg.github.com/download/@taimei-code/auth-client/1.0.0/be2d088674dbcc01116218a7521ce3f47d10a07a", { "dependencies": { "effect": "^3.19.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.0.0", "@connectrpc/connect": "^2.0.0" } }, "sha512-ms/DQPoO2nbyRqrD60uScsPalDguPAtkp6qtlVnJkgueeQRb3mu88yrOLUCZNEf1vCvwilbytygFtgsCXBRglg=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@react-email/components": "^1.0.2",
     "@sentry/nextjs": "^9",
     "@tailwindcss/forms": "^0.5.7",
-    "@taimei-code/auth-client": "^0.5.0",
+    "@taimei-code/auth-client": "^1.0.0",
     "@vercel/blob": "^1.0.0",
     "autoprefixer": "10.4.19",
     "bcrypt": "^5.1.1",


### PR DESCRIPTION
## やったこと

taimei-auth#43 + #44 で確定した `@taimei-code/auth-client@1.0.0` の VerifyResult 契約に追従する。consumer 側 call site への影響を thin wrap で最小化。

- package.json: `@taimei-code/auth-client` ^0.5.0 → ^1.0.0
- app/lib/auth-guard.ts: `createAuthGuard().getSession()` の VerifyResult を `result.ok ? result.data : null` に変換する thin wrap を追加、Result enum を再 export
- app/services/auth-service.ts: `AuthService.getSession` 内で `verifyResult.outcome.case !== "ok"` で分岐、`okValue.user/session` で proto 戻り値を読む
- __tests__/auth-guard.test.ts: mock の戻り値を VerifyResult shape に書換
- app/services/__tests__/auth-service-integration.test.ts: verifySession mock を oneof outcome shape (`{ outcome: { case: "ok" \| "error", value: ... } }`) に書換

## なぜやるのか

taimei-auth で `verifySession` の戻り型が `{ user, session } | null` から `{ outcome: oneof }` に変更され、戻り型を旧 shape で読んでいる consumer コードが TypeScript 型エラーで build 不能になる。SDK 1.0 contract に追従して runtime / 型整合を回復し、auth-guard 経由の cookieCache stale 検知 (taimei-auth 側で実装された revision 整合 check) の恩恵を taimei に届ける。

## 設計判断

`app/lib/auth-guard.ts` で `getSession` を thin wrap し、戻り型を旧来の `SessionData | null` に変換した。これにより `requireSession` / `fetchCurrentUser` / `after-signin` 等の call site 4 箇所は無変更で済む。代替案として「consumer 全 call site で `result.ok` 分岐に書換」も検討したが、taimei 内で約 6 箇所 (page.tsx 含む) が `session?.user` 形で読んでおり、書換コストと「VerifyResult 由来の追加情報 (`reason`) を consumer で使う場面がない」事実から、thin wrap で隠蔽する方針を採用。`reason === REVISION_OUTDATED` の UI 区別は将来必要になった時点で thin wrap を剥がす方が拡張容易と判断。

`@taimei-code/auth-client@1.0.0` は taimei-auth で `auth-client-v1.0.0` tag push 経由で GitHub Packages にすでに publish 済 (taimei-auth side workflow が trigger)。`bun install` でローカル取得を確認済。

## やらなかったこと

- `reason === REVISION_OUTDATED` の UI 出し分け (login URL hash 付与 `#revision_outdated`) は本 PR で実装しない。consumer に追加 UI 要件が来た時に thin wrap を剥がして対応する。CHANGELOG / SDK 仕様には migration 例として書かれている

## レビューしてほしい観点

- thin wrap で `null` 集約する判断 (`reason` の情報を捨てる) が現状の UX 要件に十分か
- AuthService.getSession (Effect.gen) で `outcome.case` 分岐を inline で書いている可読性。専用 helper `unwrapVerifyResponse` の抽出が必要か
- 既存の `auth-service-integration.test.ts` の oneof mock shape が proto-es 生成型と整合しているか

## 動作確認結果

- `bunx tsc --noEmit` exit 0
- `bun run lint` (biome + eslint) exit 0
- `bun run test` 全 86 件 PASS (auth-guard 4 件 + auth-service-integration 6 件を VerifyResult shape に書換した上で)

## Revert 手順

- [x] スキーマ変更はありません. Revert PR を作成してマージしてください

<!-- SDK upgrade のみ、DB / migration 無し -->

## セルフレビューチェックリスト

- [x] taimei-auth 側 PR (#43, #44) が main マージ済 + tag publish 完了確認済
- [x] thin wrap で call site 影響を最小化
- [x] mock test を新 oneof shape に追従

## 関連

- taimei-auth#43 (Phase 1.5 + R5: SDK 0.6.0)
- taimei-auth#44 (Phase 2: SDK 1.0.0 + buf breaking CI)
- ADR-001 (private notes): Phase 1.5 / R5 改訂版
