### PR TITLE
refactor: コードコメントから内部用語ラベルを除去 (purge-private-vocab)

### DIFF
--- a/__tests__/auth-guard.test.ts
+++ b/__tests__/auth-guard.test.ts
@@ -11,7 +11,7 @@ vi.mock("next/headers", () => ({
 
 const mockGetSession = vi.fn();
 
-// SDK 1.0.0 (ADR-001 R2) で createAuthGuard().getSession() の戻り型が VerifyResult に変更:
+// SDK 1.0.0 で createAuthGuard().getSession() の戻り型が VerifyResult に変更:
 //   { ok: true; data: SessionData } | { ok: false; reason: Result }
 // auth-guard.ts の thin wrap で { result.ok ? result.data : null } に変換する形を維持。
 vi.mock("@taimei-code/auth-client", () => ({

--- a/app/lib/auth-guard.ts
+++ b/app/lib/auth-guard.ts
@@ -21,7 +21,7 @@ const guard = createAuthGuard({
   },
 });
 
-// SDK 1.0.0 (ADR-001 R2) で戻り値が VerifyResult discriminated union 化されたため、
+// SDK 1.0.0 で戻り値が VerifyResult discriminated union 化されたため、
 // consumer 側で従来の `if (!session)` パターンを維持するための thin wrap を提供する。
 // reason が REVISION_OUTDATED のときは login URL に hash を付けてユーザーに再ログイン要因を示す
 // (現状は signin_failed への redirect で十分なので未実装、将来の UI 改善余地として残す)。
@@ -34,7 +34,7 @@ export const getSession = async (): Promise<SessionData | null> => {
 export type Session = Awaited<ReturnType<typeof getSession>>;
 export type VerifiedSession = Exclude<Session, null>;
 
-// SDK 0.5.0 で SDK 側 requireSession は廃止 (ADR-007)。redirect 制御フローと
+// SDK 0.5.0 で SDK 側 requireSession は廃止。redirect 制御フローと
 // login path 規約 `/auth?callbackUrl=` を consumer 側に集約する。
 // SDK 1.0.0 で getSession の戻り型が変わったため、上記 thin wrap 経由で従来の null チェックを維持。
 export const requireSession = async ({

--- a/app/services/__tests__/auth-service-integration.test.ts
+++ b/app/services/__tests__/auth-service-integration.test.ts
@@ -57,7 +57,7 @@ describe("AuthService.getSession (Phase 2.5 統合テスト)", () => {
   });
 
   it("token あり + verifySession が user/session を返すとセッションが返る", async () => {
-    // ADR-001 R2: VerifySessionResponse は oneof outcome へ変更
+    // VerifySessionResponse は oneof outcome へ変更
     const layer = provideMocks("test-token", {
       authService: {
         verifySession: (async () => ({

--- a/app/services/auth-service.ts
+++ b/app/services/auth-service.ts
@@ -39,7 +39,7 @@ export class AuthService extends Effect.Service<AuthService>()(
               catch: (e) => new SessionError({ cause: e }),
             });
 
-            // ADR-001 R2: VerifySessionResponse は oneof outcome に再設計済。
+            // VerifySessionResponse は oneof outcome に再設計済。
             // outcome === "ok" 以外 (error / 未設定) は全て null に集約し、consumer は
             // SDK の VerifyResult ではなく自前 SessionError でハンドリングする (Effect 層)。
             if (verifyResult.outcome.case !== "ok") return null;


### PR DESCRIPTION
## やったこと

taimei-auth SDK consumer 側のコメントから、削除済プランファイル由来の内部用語を除去する。

- app/lib/auth-guard.ts: `SDK 1.0.0 (ADR-001 R2)` → `SDK 1.0.0` / `廃止 (ADR-007)` → `廃止`
- app/services/auth-service.ts: `ADR-001 R2: VerifySessionResponse は oneof outcome に再設計済` の prefix を削除し本文維持
- __tests__/auth-guard.test.ts + auth-service-integration.test.ts: 同様にラベル削除

## なぜやるのか

taimei-auth#43-#46 の作業で参照していたプランファイルは削除済で、コメント内の `ADR-001 R2` 等の番号ラベルが参照先を失っていた。reviewer / 将来の engineer はプランを持たず、ラベルを decode 不能。本文の意味は維持してラベルだけ削除し self-contained に戻す。

## レビューしてほしい観点

ラベル削除後も本文だけで意味が通るか (test name / コメントが SDK 由来のプランを知らない reader でも読み下せるか)。

## 動作確認結果

`bunx tsc --noEmit` / `bun run lint` / `bun run test` 全 86 件 PASS。

## Revert 手順

- [x] スキーマ変更はありません. Revert PR を作成してマージしてください

## セルフレビューチェックリスト

- [x] ラベル削除後の本文が self-contained
- [x] REVISION_OUTDATED 等の Result enum 値は codebase identifier として維持
