### PR TITLE
chore(drizzle): snapshot chain warning を実態に合わせて更新

### DIFF
--- a/drizzle/0002_new_lockjaw.sql
+++ b/drizzle/0002_new_lockjaw.sql
@@ -11,8 +11,7 @@
 -- 注: drizzle-kit generate は古い 0000_snapshot.json (Prisma 由来) を base に diff を取り、
 -- 本 ADR scope 外のテーブル (User / Session / Account / UserProfile / VerificationToken /
 -- Authenticator / _prisma_migrations) の DROP まで生成したため、本 migration は手動で
--- user_profile のみに絞り直している。drizzle snapshot chain の整合 (0001_snapshot.json
--- 欠落 / 0002.prevId が 0000 を指す) は ADR-001 Phase 3 follow-up Issue で別途扱う —
--- それまで本リポで `bunx drizzle-kit generate` を実行する者は事前に follow-up Issue の
--- status を必ず確認すること (誤生成 migration を merge すると本番認証 table を破壊する)。
+-- user_profile のみに絞り直している。snapshot chain (0001_snapshot.json 欠落 / 0002.prevId
+-- が 0000 を指す) は cosmetic な不整合だが drizzle-kit は許容している (`drizzle-kit check`
+-- / `generate` / `migrate` いずれも正常動作、2026-05-23 ADR-008 実装中に検証済)。
 DROP TABLE IF EXISTS "user_profile";


### PR DESCRIPTION
## やったこと

- `drizzle/0002_new_lockjaw.sql` のヘッダコメントから snapshot chain 関連の過剰警告 (「ADR-001 Phase 3 follow-up Issue で扱う」「本番認証 table 破壊リスク」) を取り下げ
- 「cosmetic な不整合だが drizzle-kit は許容、2026-05-23 検証済」と実態に合わせた表現に変更

## なぜやるのか

ADR-008 (#510) 実装中に drizzle snapshot chain 破綻を「最重要 follow-up」として警告したが、実機検証 (`drizzle-kit check` / `generate` / `migrate` を実 DB で実行) で全て正常動作することが判明。drizzle-kit は新規 migration 生成時に「直近 snapshot のみ」を参照する設計のため、0001_snapshot.json 欠落は cosmetic な不整合に過ぎず実害なし。誤った警告を放置すると未来の読者を惑わすため、コメントを取り下げる。

## 検証

- `bunx drizzle-kit check` → `Everything's fine 🐶🔥`
- `bunx drizzle-kit generate` → `No schema changes, nothing to migrate 😴`
- `bunx drizzle-kit migrate` → `migrations applied successfully`

## チェックリスト

- [ ] CI green