### PR TITLE
chore(dev): allowedDevOrigins に app.taimei-code.local を追加

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,13 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig = {
   turbopack: {},
+  // Next.js 16 から dev server の cross-origin 保護が default 有効化された結果、
+  // `app.taimei-code.local` のような custom host で dev resources (RSC stream / HMR) が
+  // silently blocked され client-side hydration が完全停止する。本リポは README で
+  // /etc/hosts に `app.taimei-code.local` を追加して dev 動作確認する運用なので、
+  // この host を明示的に allowlist する。turbopack mode では warning も出ず原因特定が
+  // 困難なため、開発者導線として必須設定。
+  allowedDevOrigins: ["app.taimei-code.local"],
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## やったこと

- `next.config.mjs` に `allowedDevOrigins: ["app.taimei-code.local"]` を追加

## なぜやるのか

Next.js 16 から default 有効化された dev server の cross-origin 保護が `app.taimei-code.local` を不明な host として blocking し、RSC stream / hydration が silently fail する症状があった。本リポは README で /etc/hosts に `app.taimei-code.local` を追加して dev 動作確認する運用なので、この host を明示的に allowlist する。turbopack mode では warning も出ず原因特定が困難 (webpack mode に切替えた瞬間に warning が出て発覚)。production build (`next start`) では影響なし — allowedDevOrigins は dev server 専用設定。

## 発覚経緯

ADR-008 (#510) merge 後の手動 QA 中、dev 環境で NavUser dropdown が click しても開かない現象を調査。`reactRenderers: []` / `buttonsWithReact: 0` でページ全体の hydration が止まっていた。`next dev --turbopack` から `next dev` (webpack mode) に一時切替えした瞬間に `Cross-origin access to Next.js dev resources is blocked by default for safety` warning が現れて根本原因が判明。

## 検証

修正適用後:
- `elementsWithReact`: 5 / 192 → **135 / 192** (大幅増加)
- `buttonsWithReact`: 0 / 3 → **3 / 3** (全 button が React attach)
- NavUser click → Radix dropdown 開く (4 menuitems 表示)
- 「設定」click → 新規タブで `http://auth.taimei-code.local:3100/account` を開く (ADR-008 QA-H-01 PASS)

## チェックリスト

- [ ] CI green