### PR TITLE
chore(deps): @taimei-code/auth-client を 1.1.0 に exact pin (ADR-0002 Phase 0)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,28 @@
+# CONTEXT — app.taimei ドメイン用語集
+
+app.taimei（taimei 本体 / consumer）のドメイン語彙。実装詳細は持たず、概念の定義と境界のみを記す。
+認証・事業所・所属の語彙は taimei-auth 側で定義 (plans/taimei `ADR-009`)。ここでは本体ドメイン側の用語と、auth から借用する `company` の本体での意味を記す。
+
+## 用語
+
+### company（事業所）
+taimei を利用する事業者そのもの。**課金単位かつデータ分離単位**（= 本体ドメインデータが帰属する境界）。実体は taimei-auth 側で管理され、本体は SDK `getSession().companyId` 経由でのみ識別子を知る（auth の identifier への論理参照。本体に company 実体テーブルは持たない）。本体の全ドメインデータ（customer / invoice / revenue / tag）は必ずいずれか 1 つの company に帰属する。
+
+- **Avoid**: `tenant` / `organization` / `affiliation`（ADR-009 D2 / Q1 の語彙ルールと整合。データ分離の文脈でも "事業所単位の分離" と表現し "tenant 分離" とは書かない）
+
+### customer（顧客 / 請求先）
+ある company の請求先（invoice の宛先）。**company とは別概念**（company = taimei 利用者自身、customer = その利用者の取引先）。**company-private**: 同名の取引先でも company ごとに別の customer として持ち、company 間で共有・名寄せしない。
+
+- freee も取引先/顧客マスタを事業所スコープで持ち社横断共有しない（共有は顧問 (advisor) 関係に限定）。taimei MVP は顧問概念を持たない（ADR-009 D3）ため company-private で確定。
+- 社横断の顧客マスタ共有が要るのは将来の顧問機能導入時（再評価トリガー）。
+
+### invoice（請求書）
+ある company が customer に対して発行する請求。company に帰属し、customer を参照する。
+
+- 現状 invoice は customer 情報のスナップショットを持たず参照のみ（customer 編集が過去 invoice の表示に遡及する）。freee は「請求書と取引先マスタの分離」で発行時ワンタイムコピーに変更済。taimei の invoice immutability は別 ADR 候補（`docs/adr/0002` Phase E+ 参照）。
+
+### revenue（売上）
+company 単位の月次売上集計。
+
+### tag（タグ）
+company 単位のラベル。invoice 等に付与する。company-private。

--- a/app/services/__tests__/auth-client-contract.test.ts
+++ b/app/services/__tests__/auth-client-contract.test.ts
@@ -1,0 +1,15 @@
+// 型のみ import。auth-guard 経由だと server-only / ConnectRPC client の
+// module 初期化が走るため、contract 検証は SDK の型契約に限定する。
+import type { SessionData } from "@taimei-code/auth-client";
+import { expectTypeOf, it } from "vitest";
+
+// SDK と本体の境界契約。設計詳細: docs/adr/0002-company-data-scoping.md (Phase 0)。
+// scoping 機構 (PR-2 以降) は getSession().companyId を唯一の company source とするため、
+// SDK 退行で companyId が消えると本体の全 scoped query が静かに company 不定になる。
+// 型 assertion を CI 常時 (lint.yml の bun tsc --noEmit) で効かせ、退行を PR でブロックする。
+it("SDK SessionData が companyId を提供する (ADR-0002 Phase 0 contract)", () => {
+  expectTypeOf<SessionData>().toHaveProperty("companyId");
+  // 事業所未選択 user では companyId 不在のため optional。
+  // 未選択判定 (PR-2 resolveCompanyIdOrRedirect) はこの undefined を見て redirect する。
+  expectTypeOf<SessionData["companyId"]>().toEqualTypeOf<string | undefined>();
+});

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "@react-email/components": "^1.0.2",
         "@sentry/nextjs": "^9",
         "@tailwindcss/forms": "^0.5.7",
-        "@taimei-code/auth-client": "^1.0.0",
+        "@taimei-code/auth-client": "1.1.0",
         "@vercel/blob": "^1.0.0",
         "autoprefixer": "10.4.19",
         "bcrypt": "^5.1.1",
@@ -848,7 +848,7 @@
 
     "@tailwindcss/forms": ["@tailwindcss/forms@0.5.11", "", { "dependencies": { "mini-svg-data-uri": "^1.2.3" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1" } }, "sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA=="],
 
-    "@taimei-code/auth-client": ["@taimei-code/auth-client@1.0.0", "https://npm.pkg.github.com/download/@taimei-code/auth-client/1.0.0/be2d088674dbcc01116218a7521ce3f47d10a07a", { "dependencies": { "effect": "^3.19.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.0.0", "@connectrpc/connect": "^2.0.0" } }, "sha512-ms/DQPoO2nbyRqrD60uScsPalDguPAtkp6qtlVnJkgueeQRb3mu88yrOLUCZNEf1vCvwilbytygFtgsCXBRglg=="],
+    "@taimei-code/auth-client": ["@taimei-code/auth-client@1.1.0", "https://npm.pkg.github.com/download/@taimei-code/auth-client/1.1.0/e2bae519f5862ba41c9b4c0394824726fe6d3138", { "dependencies": { "effect": "^3.19.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.0.0", "@connectrpc/connect": "^2.0.0" } }, "sha512-LjfWq79JuBgHmN2n3E3AUSHqNFAnhSuDiIP1hV54PtU6+tnU0/KkBMuTrSxD72xkickWGcJxluFggfYRnWmWrw=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/docs/adr/0002-company-data-scoping.analysis.md
+++ b/docs/adr/0002-company-data-scoping.analysis.md
@@ -1,0 +1,208 @@
+# ADR-0002 company data scoping — 受け入れ条件分析
+
+### Tier
+Tier: deep (DB migration + security/IDOR scoping = リスク領域強制。schema/services/auth-guard/data/actions/package.json の 6+ ファイル multi-concern)
+
+## 受け入れ条件
+
+### 検討観点 (controlled vocabulary)
+- 機械抽出変更種別: db_change (`db/drizzle/schema.ts` + `drizzle/*.sql`), auth_change (`app/lib/auth-guard.ts` requireCompany + scoping=access control), service_change (`app/services/*-service.ts` + `index.ts` runScopedService), dependency_change (`package.json` SDK 1.1.0)
+- permission: cross-company アクセス制御 (IDOR) が本 ADR の中核なので主軸採用 (auth 文脈強調により副作用軸でなく主軸)
+- auth_state: companyId 選択状態 (未選択→redirect / 選択済→scoped) が分岐の要なので auth_change の認証状態軸を採用
+- data_compat: company_id 列追加 + backfill + NOT NULL 化 + revenue unique 変更の既存データ互換 (db_change)
+- caller: scoped 処理を runScopedService 経由に統一する call-site 正当性 + 型 closure (service_change の呼び出し元軸)
+- contract: SDK getSession() の companyId 契約 (1.1.0 提供) との境界 (Step B 汎用候補軸 contract、dependency_change の semver 文脈)
+- observability 追加: observability (理由: cross-company アクセスや scoping エラーの構造化ログで Critical 検出力を上げる、上限 5 にカウントしない特例)
+
+### 正常系
+- [ ] permission: company A の user が GET /dashboard/invoices → 自社 invoice のみ一覧 (B 社 invoice を含まない)
+- [ ] auth_state: companyId 選択済 session で /dashboard アクセス → redirect なしで scoped データ描画
+- [ ] data_compat: migration 適用後、全 scoped テーブルに `company_id` NOT NULL 列 + index が存在し既存行は backfill 済 (`SELECT count(*) WHERE company_id IS NULL` = 0)
+- [ ] caller: `data.ts`/`actions.ts` の scoped 処理が `runScopedService` 経由で実行され、`InvoiceService.findById` が `CompanyContext.companyId` を WHERE に付与する
+- [ ] contract: SDK 1.1.0 で `getSession()` が `companyId: string` / `currentCompanyName` / `currentCompanyRole` を返す (新規 signup user で `companyId` 非 null)
+- [ ] observability: scoping 経路の DB エラー時に既存 `console.error("Database Error:", ...)` 踏襲でエラーが記録される
+
+- [ ] `[MECE追加]` permission: `CustomerService.findAll` が現在の company の customers のみ返す (他社 customer は invoice 作成 dropdown / 一覧に出ない) — CR2/M1
+- [ ] `[MECE追加]` data_compat: migration 後 `revenue` の unique が `(company_id, month)` のみで `(month)` 単独 unique が残らない (別 company で同月行を作れる) — IM4
+
+### 異常系
+- [ ] permission: company A の user が他社 invoice id を直打ち GET /dashboard/invoices/&lt;B社id&gt;/edit → 404 Not Found (存在隠蔽、403 ではない)
+- [ ] auth_state: `companyId === undefined` (事業所未選択) の session で /dashboard → 302 redirect → `{NEXT_PUBLIC_AUTH_URL}/auth/signup/company`
+- [ ] data_compat: backfill 前に NOT NULL 制約を適用 → 既存 NULL 行で migration 失敗 → 3 段手順 (nullable→backfill→not null) で回避、未充足なら migration abort
+- [ ] caller: scoped Service (`yield* CompanyContext` を持つ Effect) を `runService` に渡す → `bun tsc --noEmit` でコンパイルエラー (CompanyContext not assignable)
+- [ ] contract: SDK が `^1.0.0` のまま (未 upgrade) → `getSession().companyId` が型に存在せず tsc エラー / 実行時 undefined (Phase 0 ブロッカー)
+- [ ] observability: `verifySession` outcome != "ok" → SessionError、null session として `/auth` redirect (既存 auth-guard 挙動踏襲、companyId 評価前)
+
+- [ ] `[MECE追加]` permission: 他社 invoice id で `updateInvoice` / `deleteInvoice` → 404 かつ他社行が変化しない (rows affected = 0) — CR1/BB-I1
+- [ ] `[MECE追加]` permission: `create` / `update` で自社スコープ外の `customerId` を渡す → NotFound 相当で拒否 (`customerId` の自社帰属を検証。`companyFilter` は invoices 側のみで create 入力を塞がない) — CR1/WB-C1
+- [ ] `[MECE追加]` permission: customer 一覧の集計 (`totalPaid`/`totalPending`) に他社 invoice 金額が混入しない (`fetchFiltered` の leftJoin invoices に `companyFilter` を AND) — IM1/WB-I3
+- [ ] `[MECE追加 変更]` observability: AC-12 を再定義 — scoping 経路は SDK guard `getSession` が `!ok` で null を返し `/auth` redirect する (Effect 版 `AuthService.getSession` の `SessionError` は本番呼出ゼロ=非影響確認へ。変更理由: AC-12 が実 scoping 経路でない Effect 版を指していた) — IM8/WB-N1
+
+### エッジケース (境界値チェックリストより)
+- [ ] permission [境界値: 他人]: company A user が `customerId` = B 社 customer で invoice 作成 → A 社スコープに当該 customer 無く 404/作成不可 (customer も company-private)
+- [ ] auth_state [境界値: 状態=削除済]: 唯一所属 company が DELETED 後 `companyId` undefined → redirect (membership 0 件と同等)
+- [ ] data_compat [境界値: 配列=空]: scoped テーブルが 0 行で migration → backfill no-op で正常完了 (既存「データがない場合は 0 ページ」テスト踏襲)
+- [ ] caller [境界値: 同時=複数ユーザー]: 2 タブで別 company に切替後それぞれ data fetch → 各 request の `getSession` (react.cache は per-request) が正しい companyId を導出 (cross-request 汚染なし)
+- [ ] contract [境界値: 状態=初期]: 新規 signup 直後 membership 0 件で `companyId` undefined → signup company step へ redirect
+- [ ] observability [境界値: 権限=未ログイン]: 未認証で scoped 処理 → `requireSession`/`getSession` が null → `/auth` redirect (companyId 評価に到達しない)
+
+- [ ] `[MECE追加]` permission [境界値: 他人]: 他社 tag id で invoice に tag 付与 → join 行が作られない (tags は Phase2 で scope。Phase1 完了時点は `_invoicesTotags` が列なしで A 社 invoice ↔ B 社 tag を張れる leak 窓が開く点を明示) — IM5/BB-I3
+
+### 非影響確認 (推奨)
+git 判定: 実装未着手 (plan mode、git status は ADR/CONTEXT の新規 `A` のみ)。plan 本文の変更予定ファイルは既存ファイル改変 (`M` 相当) のため (a) 手動列挙を (推定) で実施。
+- [ ] 非 scoped 認証フロー (`sendMagicLink` via `runService`) が変わらないこと (推定)
+- [ ] `after-signin` / `after-signup` ページの `getSession` 着地挙動が変わらないこと (推定)
+- [ ] dashboard layout の未認証 → `/auth` redirect が `requireCompany` 化後も維持されること (推定)
+- [ ] `runService` (非 scoped) 経路が型・実行とも従来通り (CompanyContext 非依存) であること (推定)
+- [ ] `[MECE追加]` observability: cross-company write 試行 (他社 id での mutation) を正常 not-found と区別する構造化ログ (試行 companyId / 対象 id / 経路) で記録 — IM7/M2
+- [ ] `[MECE追加]` caller: `CompanyContext` に載る companyId の供給元を session の単一 companyId と定義し、複数 company 所属ユーザーの解決 (どの company を context に載せるか) を仕様化 — IM6/M4
+
+## 技術リスク
+
+### リスク1: runScopedService の型 closure が実効か
+- **何がわからないか**: scoped Service を `runService` に渡すと本当にコンパイルエラーになるか未検証。
+- **最悪何が起きるか**: 型で防げず開発者が非 scoped 実行を書き company filter なしの IDOR が ship する。
+- **どうやって検証するか**: scoped Service を `runService` に渡す実験コードを 1 つ書き `bun tsc --noEmit` で error を確認する。
+
+### リスク2: getSession (react.cache) が Server Action 内で機能するか
+- **何がわからないか**: `runScopedService` 内の `getSession` が Server Action コンテキストで cache dedupe と `cookies()` 読取を正しく行うか不明。
+- **最悪何が起きるか**: mutation (createInvoice 等) で companyId 取得が二重 RPC / cache miss し性能劣化または取得失敗で誤 redirect が起きる。
+- **どうやって検証するか**: 未選択でない session で createInvoice を実行し `/api/auth/get-session` 呼出回数を Network tab で観測する。
+
+### リスク3: redirect() が Effect.either に飲まれないか
+- **何がわからないか**: `runScopedService` の `redirect()` が `Effect.either` 実行前 throw として NEXT_REDIRECT を正しく伝播するか未確認。
+- **最悪何が起きるか**: redirect が握り潰され未選択 user が空データ画面や 500 を見る。
+- **どうやって検証するか**: companyId undefined の session で /dashboard に実アクセスし 302 → `/auth/signup/company` を確認する。
+
+### リスク4: revenue unique 変更の migration 安全性
+- **何がわからないか**: `(month)` → `(company_id, month)` の unique 変更を drizzle-kit が drop+再作成 SQL で正しく生成し既存データで失敗しないか不明。
+- **最悪何が起きるか**: 既存 month 重複や制約 drop 漏れで migration が staging で失敗しデプロイが止まる。
+- **どうやって検証するか**: `bunx drizzle-kit generate` 後の SQL をレビューし `bun run test:db` 相当の test_db で migrate を実行する。
+
+## MECE分析結果
+
+### 分析サマリー
+- 分析日時: 2026-05-27
+- 対象リポジトリ: YasuakiOmokawa/taimei (Wiki Researcher は `[Devin未使用]` — Devin wiki 未収録、preflight で非起動)
+- ACカバレッジ: 17/30 項目充足 (元 22 のうち充足 17、`[MECE追加]` 8 件は未判定で分母に算入)
+- 漏れ件数: 4 (お見合い M1-M4)
+- 重複件数: 2 (補強し合う合意 X1/X2、真の合意 0)
+- 判定: **要修正 (Critical 2件)**
+
+### 4分類クロスリファレンス
+| # | Area | BB | WB | 分類 | Severity | 統合内容 |
+|---|---|---|---|---|---|---|
+| X1 | data | BB-I2 | WB-N2 | 補強し合う合意 | 🟡 | revenue unique 移行の最終状態検証 + read-only 前提 (id PK 不在) |
+| X2 | security | BB-I1 | WB-C1 | 補強し合う合意 | 🔴 | mutation IDOR: read 404 (BB) + write 入力注入 (WB) の別軸。create/update の customerId 無検証 + customers FK グローバル |
+| X3 | data | BB-I3 | — | 実装漏れ | 🟡 | `_invoicesTotags` が列なしで A社 invoice↔B社 tag を張れる。Phase1 は tags 未scope の leak 窓 |
+| X4 | data | — | WB-I1 | 仕様漏れ | 🟡 | invoice/customer/revenue/tags factory 不在 (factories は user のみ)。「factory に追加」でなく net-new |
+| X5 | data | — | WB-I2 | 仕様漏れ | 🟡 | `effect-test-helpers` が CompanyContext 未提供 → scoped 化で既存テストもコンパイル不能 |
+| X6 | security | — | WB-I3 | 仕様漏れ | 🟡 | `customer-service.fetchFiltered` の leftJoin invoices に company AND 無く金額 leak |
+| X7 | auth | — | WB-N1 | 仕様漏れ | 🟢 | AC-12 の SessionError は Effect 版の挙動。scoping 経路 (SDK guard) は !ok で null |
+| X8 | auth | — | WB(AC-5) | 仕様漏れ | 🟡 | SDK ^1.1.0 upgrade が全 session-companyId AC の blocking 前提 (現行 1.0.0) |
+| M1 | security | — | — | お見合い | 🔴 | `CustomerService.findAll` 無 scope。dropdown だけが防御になり API 直叩きで崩れる |
+| M2 | observability | — | — | お見合い | 🟡 | cross-company write 試行の監査ログ (正常 not-found と区別) |
+| M3 | concurrency | — | — | お見合い | 🟢 | create の customerId 検証を SELECT→INSERT 2 段にすると TOCTOU 窓 |
+| M4 | auth | — | — | お見合い | 🟡 | CompanyContext 供給元 (複数 company 所属の解決) が未定義 |
+
+### ACカバレッジ検証結果
+| AC-ID | 要約 | カテゴリ | BB | WB | 総合 |
+|---|---|---|---|---|---|
+| AC-1 | 自社 invoice のみ一覧 | 正常系 | 充足 | 充足 | 充足 |
+| AC-2 | 選択済→scoped 描画 | 正常系 | 充足 | 充足 | 充足 |
+| AC-3 | company_id NOT NULL + index + backfill | 正常系 | 不十分 | 充足 | **不十分** (revenue unique 検証欠落) |
+| AC-4 | runScopedService 経由 + WHERE 付与 | 正常系 | 充足 | 充足 | 充足 |
+| AC-5 | SDK getSession companyId 返却 | 正常系 | 充足 | 不十分 | **不十分** (SDK ^1.1.0 upgrade 前提) |
+| AC-6 | DB エラー console.error 踏襲 | 正常系 | 充足 | 充足 | 充足 |
+| AC-7 | 他社 id GET/edit → 404 | 異常系 | 不十分 | 充足 | **不十分** (update/delete 未 AC 化) |
+| AC-8 | 未選択→302 signup/company | 異常系 | 充足 | 充足 | 充足 |
+| AC-9 | NOT NULL 化 3 段 | 異常系 | 充足 | 充足 | 充足 |
+| AC-10 | scoped Service を runService → tsc エラー | 異常系 | 充足 | 充足 | 充足 |
+| AC-11 | ^1.0.0 のまま → 型エラー | 異常系 | 充足 | 充足 | 充足 |
+| AC-12 | verifySession !ok → redirect | 異常系 | 充足 | 不十分 | **不十分** (経路ずれ、再定義要) |
+| AC-13 | 他社 customerId で作成不可 | エッジ | 充足 | 不十分 | **不十分** (create 無検証注入=Critical) |
+| AC-14 | DELETED 後 undefined→redirect | エッジ | 充足 | 充足 | 充足 |
+| AC-15 | 0 行 migration no-op | エッジ | 充足 | 充足 | 充足 |
+| AC-16 | 2 タブ別 company per-request | エッジ | 充足 | 充足 | 充足 |
+| AC-17 | 新規 signup membership 0→redirect | エッジ | 充足 | 充足 | 充足 |
+| AC-18 | 未認証→/auth | エッジ | 充足 | 充足 | 充足 |
+| AC-19〜22 | 非影響 (sendMagicLink/after-sign/layout/runService) | 非影響 | 充足 | 充足 | 充足 |
+| `[MECE追加]` 8 件 | findall scope / revenue unique / update-delete IDOR / create customerId / 集計 leak / tag join / write 監査 / CompanyContext 供給元 | 各カテゴリ | 未判定 | 未判定 | 未判定 |
+
+総合「不十分」: AC-3 / AC-5 / AC-7 / AC-12 / AC-13 (5 件)。
+
+#### MECE分析によるAC追加提案 (本ファイルの各カテゴリに追記済)
+- `[MECE追加]` update/delete の他社 id → 404 + rows affected=0 (CR1)
+- `[MECE追加]` create/update の customerId 自社帰属検証 (CR1)
+- `[MECE追加]` CustomerService.findAll の company scope (CR2)
+- `[MECE追加]` 集計 leftJoin の金額 leak 防止 (IM1)
+- `[MECE追加]` revenue unique (company_id, month) 最終状態検証 (IM4)
+- `[MECE追加]` _invoicesTotags の cross-company 結合不可 (IM5)
+- `[MECE追加]` cross-company write 試行の監査ログ (IM7)
+- `[MECE追加]` CompanyContext 供給元の仕様化 (IM6)
+- `[MECE追加 変更]` AC-12 を SDK guard null 経路へ再定義 (IM8)
+
+### Critical指摘 (要修正)
+| # | 指摘 | プラン該当箇所 | 推奨修正 | 根拠 | 4分類 |
+|---|---|---|---|---|---|
+| CR1 | mutation 経路 IDOR: update/delete の他社行不可視 + create/update の customerId 自社帰属検証が欠落。`companyFilter` は invoices 側のみで、create 入力の customerId はグローバル FK 経由で他社注入可 | D2 (create 例 `{...input, companyId}`)・D3 (3 重閉じ) | (1) update/delete に `companyFilter` を AND し他社 id は 404 + rows=0、(2) create/update で customerId の自社帰属を検証、(3)「型・companyFilter だけでは create 入力を塞がない」を D3 の例外として明記、(4) isolation テストに update/delete/create の cross-company 検証を必須化 | BB-I1 + WB-C1 (X2) | 補強し合う合意 |
+| CR2 | `CustomerService.findAll` (customer-service.ts:14-28) が全 customers 無条件返却。invoice 作成 dropdown のソースで、CR1 と対で塞がないと「dropdown だけが防御」状態 | D1 (customers scope)・D4 (scoped helper 規約) | `findAll` を `companyFilter` 経由に。dashboard 等の全 list/aggregate 経路も company scope 棚卸し (T1) | M1 + T1 (お見合い→Critical 昇格) | お見合い |
+
+### Important / Nice-to-have
+| # | 重要度 | 指摘 | 推奨対応 | 根拠 |
+|---|---|---|---|---|
+| IM1 | 🟡 | 集計 leftJoin の他社金額 leak | `fetchFiltered` の leftJoin ON に invoices `companyFilter` を AND | WB-I3/X6 |
+| IM2 | 🟡 | isolation テスト基盤不在 (factory 群 + CompanyContext helper) | Phase1 に factory 新規作成 + `effect-test-helpers` への CompanyContext 注入を追加 | WB-I1/I2/X4/X5 |
+| IM3 | 🟡 | SDK ^1.1.0 upgrade が全 session-companyId AC の blocking 前提 | Phase0 を明示的 blocking precondition 化 | WB(AC-5)/X8 |
+| IM4 | 🟡 | revenue unique 移行の最終状態検証 + read-only 前提 | data_compat に unique 状態 AC 追加、read-only を 1 文補足 | BB-I2/WB-N2/X1 |
+| IM5 | 🟡 | `_invoicesTotags` の cross-company 結合 (Phase1 leak 窓) | tag 付与時の他社 tag join 不可を AC 化、Phase1 leak 窓を明示 | BB-I3/X3 |
+| IM6 | 🟡 | CompanyContext 供給元 (複数 company 所属解決) 未定義 | session 単一 companyId か選択 UI かを仕様化 | M4 |
+| IM7 | 🟡 | cross-company write 試行の監査ログ | mutation IDOR 試行を構造化ログで記録 (read 監査より優先) | M2 |
+| IM8 | 🟡 | AC-12 の検証経路ずれ (SessionError vs SDK guard null) | AC-12 を SDK guard null 経路に再定義、Effect 版は非影響確認へ | WB-N1/X7 |
+| N1 | 🟢 | create customerId 検証の TOCTOU | INSERT...WHERE EXISTS / FK+company 複合制約で原子化 | M3 |
+| N2 | 🟢 | company_id index 設計 | invoices/customers/revenue に company_id 前置の複合 index | T2 |
+| N3 | 🟢 | returnTo 往復 / data 経路 default 着地 | page 経路で returnTo 往復の正常系 AC、data 経路 default はトレードオフ明記 | BB-N2 |
+
+### お見合い検出 (Red Team 独自)
+| # | 領域 | 観点 | 発見事項 | Severity |
+|---|---|---|---|---|
+| M1 | security | 暗黙の前提 | CustomerService.findAll 無 scope → CR2 昇格 | 🔴 |
+| M2 | observability | 責任の継ぎ目 | cross-company write 試行の監査欠落 | 🟡 |
+| M3 | concurrency | 純技術リスク | create customerId 検証の TOCTOU | 🟢 |
+| M4 | auth | 楽観的見積もり | CompanyContext 供給元 (複数所属) 未定義 | 🟡 |
+
+### 純技術リスク補完 (Red Team)
+| # | 観点 | 発見事項 | Severity |
+|---|---|---|---|
+| T1 | security (A01) | findAll 以外の list/aggregate 経路も company scope 棚卸し必要 | 🟡 |
+| T2 | performance | company_id 複合 index が migration に含まれるか (fetchFiltered ilike OR の full scan 対策) | 🟢 |
+
+### Red Teamレビューサマリー
+<details>
+<summary>Red Team 統合評価レポート (要点)</summary>
+
+- 判定: 要修正 (Critical 2件: CR1 mutation IDOR / CR2 findAll 無 scope)
+- 重複: 補強し合う合意 X1/X2 のみ、真の合意 0 (BB=仕様軸 / WB=コード軸で根拠層が一貫分離)
+- AC-7 で BB=write軸 / WB=read軸 と評価視点が直交していたのが独立性の証左
+- load-bearing claim を実機裏取り: create 無検証 insert (invoice-service.ts:27-43)、customers FK グローバル (schema.ts:54-61)、findAll 無 scope (customer-service.ts:14-28)、SDK guard !ok→null (auth-guard.ts:30)
+- 確信度: 高
+</details>
+
+### 各ロール分析詳細
+<details>
+<summary>BB Analyst (仕様、[Devin未使用])</summary>
+
+Critical 0 / Important 3 (BB-I1 mutation 404 未AC化, BB-I2 revenue unique 検証欠落, BB-I3 join 不変条件+Phase1 leak窓) / Nice 2 (BB-N1 cross-company 監査, BB-N2 returnTo 往復)。AC 判定: 20/22 充足、AC-3/AC-7 不十分。
+</details>
+
+<details>
+<summary>WB Analyst (コード)</summary>
+
+Critical 1 (WB-C1 = AC-13 create の他社 customerId 注入) / Important 3 (WB-I1 factory 不在, WB-I2 helper の CompanyContext 欠落, WB-I3 集計 join 金額 leak) / Nice 2 (WB-N1 AC-12 経路ずれ, WB-N2 revenue PK 不在)。AC 判定: AC-5/AC-12/AC-13 不十分、他 充足。
+</details>
+
+<details>
+<summary>Wiki Researcher</summary>
+
+`[Devin未使用]` — カレントリポ YasuakiOmokawa/taimei が Devin wiki 未収録。preflight (0-4.5) で `${DEVIN_COVERAGE}=none` 確定、Wiki Researcher 非起動。
+</details>

--- a/docs/adr/0002-company-data-scoping.md
+++ b/docs/adr/0002-company-data-scoping.md
@@ -1,0 +1,480 @@
+# ADR-0002: taimei 本体ドメインデータの company_id scoping
+
+- **Status**: Proposed
+- **Date**: 2026-05-26
+- **References**: taimei-auth 事業所概念 ADR ([#55](https://github.com/taimei-code/taimei-auth/pull/55)〜[#63](https://github.com/taimei-code/taimei-auth/pull/63)、設計ログは plans/taimei `ADR-009`)。本 ADR 内の `ADR-009 §...` 参照はこの事業所概念 ADR を指す
+
+## Context
+
+### 現状 (account 管理集約 = taimei-auth `/account` 完了時点)
+
+- ドメインテーブルに事業所単位の分離概念が一切ない。`db/drizzle/schema.ts:15-111` の `customers` / `invoices` / `revenue` / `tags` / `tags2` / `_invoicesTotags` は全て `company_id` 列を持たず、PK は `uuid().defaultRandom()` の単一列 (`schema.ts:16,23,34,41`)。今は全 user が全 invoice / customer を共有しており、scoping が **最初の事業所境界** になる。
+- 全 DB アクセスは Effect Service に集約済 (`app/services/invoice-service.ts` 等が `PgDrizzle` を直接使用)。実行は `app/services/index.ts:81` の singleton `Live` runtime (`runService`)。
+- query は無 scope。`InvoiceService.findById(id)` は `WHERE invoices.id = id` のみで company チェックなし = IDOR の温床。`update` / `delete(id)` / `app/lib/actions.ts` の `updateInvoice(id)` / `deleteInvoice(id)` も同様。
+- ページ保護は `app/lib/auth-guard.ts:28-48` の SDK guard 経由 `getSession()` / `requireSession()`。`app/dashboard/layout.tsx` が `requireSession` を使用。`proxy.ts:38-66` の Next middleware は **cookie 存在チェックのみ**で session 検証を taimei-auth に委譲 (RPC を叩かない)。
+
+### 本 ADR の trigger と責任境界 (ADR-009 Q12)
+
+ADR-009 §2.1 D5 / Q12 結論で、taimei-auth 側は「session に `current_company_id` を持つ / proto `Session.company_id` 活性化 / SDK `getSession()` に `companyId` 追加」までを担い、**「taimei 本体のドメインデータを `company_id` で scope する作業」は本体リポ側の別 ADR (= 本 ADR)** に切り出された。trigger は「SDK が `companyId` 提供開始」で、ADR-009 §12 Phase A〜D 完了 (2026-05-25) で充足。
+
+### SDK ギャップ (観測事実・Phase 0 のブロッカー)
+
+本体にインストール済の SDK は **1.0.0** (`package.json:42` の `^1.0.0`) で、`SessionData` は `user` / `session` のみ・**`companyId` を提供していない** (`node_modules/@taimei-code/auth-client/dist/types.d.ts:2-17` で観測)。taimei-auth は ADR-009 §12.1 PR #57 で **`1.1.0`** を publish し `SessionData.companyId` (flat shape: `companyId` / `currentCompanyName` / `currentCompanyRole`、source は `user.last_used_company_id`) を提供済。
+
+→ **本 ADR の Phase 0 は「本体の SDK を `1.1.0` へ upgrade」**。`^1.0.0` のまま放置すると `getSession().companyId` が永遠に来ないため、他全 Phase の前提。
+
+### 既存 query 層が Effect Service に集約済であること
+
+`.claude/rules/effect-patterns.md` の「全データアクセスを Effect-TS サービス経由に統一 / Service が PgDrizzle を直接使用 (Repository 層不要)」が既に徹底されているため、scoping を「各 query に手で WHERE を足す」のではなく **「company context を DI 層で 1 箇所に注入する」**形に倒せる。これが主機構選定 (D2) の前提。
+
+## Decision
+
+### D1. scoping 対象は実ドメイン 5 テーブル全て
+
+`customers` / `invoices` / `revenue` / `tags` / `tags2` の全てに `company_id` を追加し per-company にする。`_invoicesTotags` は join テーブルで両端 (`invoices` / `tags`) が scoped なので列追加は不要 (両端の scope で従属的に分離される)。ただし join 行自体は company 列を持たず DB 制約では cross-company 結合を防げないため、tag 付与は必ず scoped な invoices/tags 経由に限定する。tags scoping は Phase 2 のため **Phase 1 完了時点は leak 窓が開く**点に注意 (MECE IM5)。
+
+`revenue` は `fetchRevenue` が dashboard overview で読まれるため、scope しないと **overview の売上チャートが全社横断で漏れる**。`tags` / `tags2` は社ごとのラベル辞書とする。
+
+`customers` は **company-private** とする: `company_id` 列を足すだけ (中間テーブルなし)、同名取引先でも company ごとに別行を持ち社間で共有・名寄せしない。`customer` (= ある company の請求先) と `company` (= テナント) は別概念 (CONTEXT.md 参照)。これは freee が取引先/顧客マスタを **事業所スコープ**で持ち社横断共有しない構造と一致する (Sources「freee 参考調査」)。社横断の顧客共有は freee でも顧問 (advisor) 関係限定で、taimei MVP は顧問概念を持たない (ADR-009 D3) ため company-private で確定。
+
+**list / aggregate メソッドも明示 scope (MECE CR2/IM1)**: 行を返す全経路を漏れなく scope する。特に `CustomerService.findAll` は invoice 作成 dropdown のソースで現状 全件返すため `companyFilter` を通す。`fetchFiltered` の `customers × invoices` leftJoin 集計 (`totalPaid`/`totalPending`) は join 先 invoices にも `companyFilter` を AND しないと他社金額が混入する (customers 側を絞っても join で漏れる)。
+
+> 本 ADR の眼目は「customers / invoices で再利用可能な scoping pattern (機構 + IDOR 防御 + redirect 配置) を確立し、残テーブルと将来の新テーブルが同じ規約に従う」こと。
+
+### D2. 主機構: `CompanyContext` (Effect DI)
+
+per-request の companyId / role を保持する Effect サービス。`effect-patterns.md` の「複数 Layer バリアントが要るなら `Effect.Tag`」に該当 (本番は per-request 注入、テストは固定値注入)。
+
+```ts
+// app/services/company-context.ts
+export interface CompanyContextShape {
+  readonly companyId: string;
+  readonly role: string; // SDK の open Role 型 (proto enum re-export、exhaustive switch 回避: ADR-009 NC2)
+}
+
+export class CompanyContext extends Effect.Tag("services/CompanyContext")<
+  CompanyContext,
+  CompanyContextShape
+>() {
+  static of = (ctx: CompanyContextShape) => Layer.succeed(this, ctx);
+}
+```
+
+各 Service は `yield* CompanyContext` で companyId を引き、scoped query に適用する:
+
+```ts
+// InvoiceService.findById — 他社 id は WHERE で除外 → 空 → InvoiceNotFound (404)
+findById: (id: string) =>
+  Effect.gen(function* () {
+    const { companyId } = yield* CompanyContext;
+    const result = yield* Effect.tryPromise({
+      try: () => pgdrizzle.select({ /* ... */ }).from(invoices)
+        .where(and(eq(invoices.id, id), companyFilter(invoices, companyId)))
+        .then((r) => r.at(0)),
+      catch: (e) => new InvoiceServiceError({ message: `findById failed: ${e}` }),
+    });
+    if (!result) return yield* new InvoiceNotFound({ id });
+    return result;
+  }),
+
+// create — companyId は context から。引数では受けない (取り違え防止)
+create: (input) =>
+  Effect.gen(function* () {
+    const { companyId } = yield* CompanyContext;
+    return yield* Effect.tryPromise({
+      try: () => pgdrizzle.insert(invoices).values({ ...input, companyId }).returning(),
+      /* ... */
+    });
+  }),
+```
+
+**create / update の外部参照 (`customerId`) は別途自社帰属を検証する (MECE CR1)**: `companyFilter` は invoices 行の read/update/delete を絞るが、INSERT/UPDATE 入力の外部 FK (`customerId`) の帰属は絞らない。`customers` FK はグローバルなので、他社 `customerId` を渡すと invoice 自体は自社 companyId で作られてしまう (cross-company 参照注入)。create/update は context の companyId で `customerId` の自社帰属を検証し、スコープ外なら `InvoiceNotFound` 相当で拒否する (型・`companyFilter` だけでは塞がらない = D3 の 3 重閉じの例外)。
+
+**`CompanyContext` は companyId のみ持ち role は入れない (freee 調査で裏付け)**: `CompanyContext` は scoping (= どの company のデータか) のみを担い、authorization (= 何ができるか) を持たない。freee も認可を session/membership とは別の専用層に置く — membership が持つのは「属性」(従業員 / アドバイザー) で、実際の権限判定は `AclKit` / `sekisyo` 権限セット (`PrivilegeControlService#xxx:read/:write` を controller `before_action` でチェック → 401/403) という別レイヤー (Sources「freee 参考調査」)。よって taimei も RBAC が必要になった時は `CompanyContext` を拡張せず、別の authorization 層 (例: `AuthorizationContext` + permission チェック) を新規に足す (Phase E+)。role は `requireCompany` が nav 表示用に session から返すので page 層では参照可能。
+
+### D3. companyId の source は scoping 境界の内側で session から導出する (呼出側に渡させない)
+
+`runScopedService` は **companyId を引数で受けない**。境界の内側で認証済 session (SDK guard 経由・`react.cache` 済) から導出する。これにより「呼出側が間違った/欠けた companyId を渡す」経路が API から消える。
+
+```ts
+// app/services/index.ts。既存 runService (company 不要処理) はそのまま残す。
+// makeNextRuntime は runtime を共有 export し、scoped/非 scoped が同一 ManagedRuntime を使う
+// (runScopedService が runtime を再構築して runtime 集約の層分離を崩すのを防ぐ):
+export const makeNextRuntime = <R, E>(layer: Layer.Layer<R, E, never>) => {
+  const runtime = ManagedRuntime.make(layer);
+  const run = <A, E2>(body: () => Effect.Effect<A, E2, R>) =>
+    runtime.runPromise(Effect.either(body()));
+  return { run, runtime };
+};
+const { run: runService, runtime } = makeNextRuntime(Live);
+
+// AllScopedServices は Live の ROut から機械導出 (手書き union 禁止 = Service 追加時の scoping 漏れ防止)。
+type AllScopedServices = Layer.Layer.Success<typeof Live>;
+
+// IDOR backstop 番兵 (閉じ1 を規律でなく型で固定): CompanyContext を Live に含めると
+// companyId 無し実行が型で通り backstop が破れる。含めた瞬間に下行がコンパイルエラーになる。
+type _NoCompanyContextInLive =
+  [CompanyContext] extends [AllScopedServices] ? "ERROR: CompanyContext must NOT be in Live" : true;
+const _assertNoCompanyContextInLive: _NoCompanyContextInLive = true;
+
+export const runScopedService = async <A, E>(
+  body: () => Effect.Effect<A, E, AllScopedServices | CompanyContext>,
+) => {
+  // 未選択判定 + redirect は requireCompany と共有 (redirect SSOT、D5)。Next 境界でしか取れない。
+  const { companyId, role } = await resolveCompanyIdOrRedirect();
+  return runtime.runPromise(
+    Effect.either(
+      body().pipe(Effect.provideService(CompanyContext, { companyId, role })),
+    ),
+  );
+};
+```
+
+呼出側 (`app/lib/data.ts` / `app/lib/actions.ts`) は companyId を一切扱わない:
+
+```ts
+export async function fetchInvoiceById(id: string) {
+  const result = await runScopedService(() =>
+    Effect.gen(function* () {
+      const service = yield* InvoiceService;
+      return yield* service.findById(id);
+    }),
+  );
+  // InvoiceNotFound → null → not-found ページ
+}
+```
+
+**3 重の閉じ**:
+1. Service が `yield* CompanyContext` を持つ → 型上 `CompanyContext` が `R` に乗り、`runScopedService` (provideService 済) でしか実行できない。`runService` に渡すとコンパイルエラー → 「company-scoped 処理を context 無しで実行」が型で不能。**前提不変条件「`CompanyContext` を `Live` に含めない」は規律でなく型で固定する**: 上記 `_NoCompanyContextInLive` 番兵が `Live` の ROut に `CompanyContext` が混入した瞬間コンパイルエラーを出す。`AllScopedServices` も `Live` から機械導出し手書き union にしない (Service 追加時の漏れ防止)。`bun tsc --noEmit` でこの閉じが成立することを CI で確認 (Phase 1 AC)。
+2. `runScopedService` は companyId 引数を持たない → 呼出側が値を供給する経路が存在しない。
+3. companyId は認証済 session から導出 → リクエストパラメータ由来の companyId injection (IDOR) も不能。
+
+**3 重閉じが守らない範囲 (MECE CR1/CR2、Phase 1 で対応)**: この 3 重は「どの company の文脈で実行するか」を保証するが、以下は型・境界・session 導出では塞がらず個別対応が要る —
+- **mutation 入力の外部 FK**: `create`/`update` の `customerId` は `companyFilter` 対象外 (グローバル FK)。context の companyId で自社帰属を検証する (D2)。
+- **無 scope な list / aggregate メソッド**: `CustomerService.findAll` 等は全件返すため明示的に `companyFilter` を通す。`fetchFiltered` の join 集計も join 先に `companyFilter` を AND する (D1)。
+- **update / delete の他社行**: WHERE に `companyFilter` を AND し、他社 id は 0 行 hit = 404 + rows affected=0 (D6)。
+
+**redirect の責務分割**: `redirect()` は Next.js の control-flow throw で Effect 内では実行不能。「未選択判定 + redirect」は素の async fn である `runScopedService` の冒頭 (= Next 境界) に置く。「取り出した companyId で query を絞る」のは Effect の責務。companyId は「Next 境界で session から取り出し → 値として Effect へ注入」の一方向に倒す。
+
+### D4. fail-open backstop: scoped ヘルパー規約 + テーブル別 isolation テスト
+
+`CompanyContext` 方式は「`yield* CompanyContext` で取った companyId を WHERE に入れ忘れても型エラーにならない」点で fail-open。これを以下で塞ぐ:
+
+- **scoped クエリヘルパー規約** (`db/scoped.ts` 新規): 生の `eq(table.companyId, ...)` を Service に直書きせず、唯一の入口 `companyFilter` 経由にする。grep / review / lint が scoping 漏れを機械的に探せる。
+
+```ts
+// db/scoped.ts — company_id を持つ全テーブルの scoping 条件の SSOT
+export const companyFilter = <T extends ScopedTable>(table: T, companyId: string) =>
+  eq(table.companyId, companyId);
+// select は and() で合成、update/delete も where に必須合成、insert は values に companyId を必ず set
+```
+
+- **テーブル別 isolation テスト** (必須): 2 社 seed し、各 Service method の select / update / delete の cross-company 不可視 + create の company_id 自動付与 + create の他社 customerId 拒否 + findAll の自社限定を検証 (テスト戦略節)。これが backstop の実体。**ただしテスト基盤は net-new**: 現状 factory は `user` のみ・`effect-test-helpers` は `CompanyContext` 未提供のため、factory 群新規作成 + helper への `CompanyContext` 注入が前提 (MECE IM2、Phase 1 タスク)。
+
+RLS は採らない (Alternatives Considered、本番課金前には過剰)。ast-grep/lint で「scoped テーブルへの `companyFilter` 無し直アクセス」を検出するルールは将来硬化候補 (Phase E+)。
+
+### D5. redirect 配置: `runScopedService` が権威ガード、`requireCompany` は page UX
+
+- **データ層の権威ガード = `runScopedService` 自身**: 未選択は必ず redirect、全 scoped query は session 由来 companyId で絞られる。`proxy.ts` は cookie 存在チェックのまま不変 (RPC を叩かず companyId を見られないため、ここに redirect は置けない)。
+- **`requireCompany()` (`app/lib/auth-guard.ts` に追加) は page レベル UX 用**: `requireSession()` を内包し、data fetch に入る前に layout で redirect して描画チラつきを防ぐ / nav に会社名を出す。security backstop ではない。`requireCompany` を呼び忘れた page があっても、その下の `runScopedService` が必ず redirect するので穴にならない。両者は同じ `cache()` 済 getSession を読むので RPC は増えない。
+
+```ts
+// app/lib/auth-guard.ts — page UX 用の thin wrapper (redirect/companyId 導出は resolveCompanyIdOrRedirect に集約)
+export const requireCompany = async ({ returnTo }: { returnTo: string }) => {
+  const { companyId, role, session } = await resolveCompanyIdOrRedirect(returnTo);
+  return { ...session, companyId, role }; // nav 表示用に session も返す
+};
+```
+
+redirect 先 `/auth/signup/company` は taimei-auth web SPA 上 (ADR-009 D6)。本体は `NEXT_PUBLIC_AUTH_URL` を base に絶対 URL を組む (`proxy.ts` の AUTH_URL 解決と同型)。`buildCompanySignupUrl(returnTo?)` は returnTo を optional とし、page 経路 (`requireCompany`) は現 path を渡し、data 経路 (`runScopedService`) は省略して default に倒す。SDK 側に同 helper を持たせるかは taimei-auth リポの判断 (本 ADR は consumer 側で構築)。
+
+**redirect / companyId 導出の SSOT (review-design 指摘)**: 未選択判定・redirect・companyId 取り出しが `runScopedService` (D3) と `requireCompany` で二重定義されないよう、`resolveCompanyIdOrRedirect()` 1 helper に集約し両者が呼ぶ。未認証 (session null) と「認証済・事業所未選択」で redirect 先を分岐する:
+
+```ts
+// app/lib/auth-guard.ts — redirect + companyId 導出の SSOT
+export const resolveCompanyIdOrRedirect = async (returnTo = "/dashboard") => {
+  const session = await getSession(); // react.cache 済
+  if (!session) redirect(`/auth?callbackUrl=${encodeURIComponent(returnTo)}`); // 未認証 → login
+  if (!session.companyId) redirect(buildCompanySignupUrl(returnTo)); // 認証済・事業所未選択 → 登録
+  return { companyId: session.companyId, role: session.currentCompanyRole ?? "MEMBER", session };
+};
+```
+
+`requireCompany` は nav 表示用に `session` も返す薄い wrapper、`runScopedService` は `{ companyId, role }` のみ使う。
+
+### D6. cross-company アクセスは 404 (403 ではない)
+
+scoped query が WHERE で他社行を除外 → `findById` が空 → 既存 `InvoiceNotFound` → not-found ページ (404)。**存在自体を漏らさない**のが best practice。ADR-009 §3.3 の「403 contract」は "事業所未選択" ケース向けで、本体では未選択は redirect (D5)、他社リソースは 404 に倒す。404 を選ぶと「IDOR 防御」と「存在隠蔽」が scoped query 1 つで同時に満たされる。
+
+同様に **`update` / `delete` も WHERE に `companyFilter` を AND** し、他社 id は 0 行 hit = 404 + rows affected=0 (他社データを変更しない)。read だけでなく write/delete の IDOR も塞ぐ (MECE CR1)。
+
+### D7. id はグローバル一意 UUID のまま、`company_id` は非 PK の追加列 (URL 衝突なし)
+
+`company_id` は scoping 用の**追加列**で、PK には**含めない** (composite PK にしない)。id 系は全て `uuid().defaultRandom()` の単一列 PK (`schema.ts:16,23,34,41`) で、DB が company を問わずテーブル全域で一意性を強制する。列を 1 本足しても既存 PK の一意性は変わらないため、`/dashboard/invoices/[id]/edit` の `[id]` は常にちょうど 1 行 (= ちょうど 1 社) に対応し URL が duplicate になる余地はない。
+
+副次効果: id がグローバル一意 (company_id を含まない) なので、id 自体が company を露呈せず、他社 UUID を入手しても scoped query が空を返す (D6) = 列挙攻撃にも強い。
+
+> 例外として「人間可読の社内連番 (例: 請求書番号が社ごとに 1 から振り直す)」が要るなら、それは PK の `id` (UUID) とは別の display-id 列で `(company_id, invoice_no)` 複合一意が必要になる。本 ADR スコープ外で Phase E+ 候補。
+
+### D8. 二重 getSession 経路の扱い
+
+companyId の source は **`runScopedService` 内 / `requireCompany` の SDK guard 経由 `getSession()` 一本**に統一。Effect の `AuthService.getSession` (`app/services/auth-service.ts`、`verifySession` 手動マッピング) は **本番呼出ゼロ (テスト専用)** なので companyId を足さない (proto 新フィールドのマッピング・モック更新の保守負債だけ増え、読む本番コードが無い)。本 ADR では触らない。
+
+なお scoping 経路の実挙動は **SDK guard `getSession` が `!ok` で null を返し `/auth` redirect** であり、`SessionError` を投げる Effect 版とは別物。検証 AC は SDK guard 経路 (null → redirect) を対象にする (`SessionError` は本番呼出ゼロのため非影響確認に留める、MECE IM8)。
+
+`AuthService.getSession` は `Live` に配線されたままだが **companyId を返さない契約**である点をコメント/命名で明示し、将来 consumer が付く時は SDK guard 経由へ寄せる (review-design Hexagonal: 同一 auth port に 2 実装が並立する contract 不明示の緩和。`CompanyContext` 不在なら scoped Service はコンパイル不能 = 閉じ1 が backstop)。
+
+### D9. migration / backfill
+
+各テーブルに `company_id varchar(32)` (auth `company.id` = `cmp_<nanoid24>` ≒ 28 文字への論理参照、**FK は張らない** = cross-DB) + index を追加。`revenue` の unique は `(month)` → `(company_id, month)` に変更。`revenue` は id PK を持たず read-only 前提 (アプリに write path なし)。migration 後は `(month)` 単独 unique が残らず `(company_id, month)` のみになることを SQL で確認する (MECE IM4)。company_id 列には index を張り、`fetchFiltered` の検索は company_id 前置の複合 index を検討 (MECE N2)。
+
+**前提 (調査で確定): 永続的な seed データは存在しない**。test DB は factory がトランザクション内で行を生成し毎テスト rollback (`app/services/__tests__/db/effect-test-helpers.ts`)、`scripts/` / `dump/` は空、`app/lib/placeholder-data.ts` は Next.js チュートリアルの未使用残骸。よって「既存 demo データの backfill」はほぼ不要で、対応は 2 系統に分かれる:
+
+- **test DB**: backfill 不要。factory (`app/services/__tests__/factories`) に `company_id` を追加し行生成時に必ず set。isolation テストは 2 つの company_id で seed (D4)。
+- **dev/staging DB**: ad-hoc な手入力行のみで throwaway。`company_id NOT NULL` を安全に足すため **nullable 追加 → 既存行があれば placeholder company_id へ backfill (無ければ no-op) → not null 化** の 3 段 (冪等、ADR-009 §2.1 D8 の `drizzle/manual/` 哲学を踏襲)。placeholder は auth の特定 company に結合しない単純固定値で可 (意味あるデータは signup フロー or factory 由来)。意味ある dev データが要るなら dev DB を reset して UI signup で作り直す。
+
+auth-coupled な sentinel (実 company id の埋め込み) は不要 (cross-DB 結合を避ける)。`app/lib/placeholder-data.ts` はこの機に削除 or company_id 対応する (未使用残骸の整理、Phase 1 任意タスク)。
+
+## Alternatives Considered
+
+| 案 | 採用しなかった理由 | 再評価トリガー |
+|---|---|---|
+| **RLS を主軸 (DB 強制 scoping)** | per-tx `SET app.current_company_id` + PgDrizzle pooling 整合・RLS テスト負担が本番前には過剰。全 query が Effect Service に集約済なので DI 注入で十分 | 本番課金開始 / 初の実顧客企業 (company) 受入 / pen-test での IDOR 指摘 |
+| **companyId を全 method の明示引数に** | 呼出側が値を供給できる = 取り違え IDOR の面が残る。CompanyContext を選んだ目的 (呼出側を companyId 取り回しから外す) と矛盾 | admin が他社を代理閲覧 / session 非依存の background job で別 companyId scope が要る時 (その時だけ監査ログ必須の明示経路を追加) |
+| **Effect 版 `AuthService.getSession` に companyId 追加** | 本番 consumer ゼロのデッドコード (D8) | Effect 版に本番 consumer が付き company context を要する時 |
+| **`company_id` を composite PK に含める** | id は UUID で既にグローバル一意。複合化は一意性に寄与せず join/URL を複雑化 | 社内連番 display-id を導入する時 (別列で対応、PK は据え置き) |
+| **ast-grep/lint で未 scoped 直アクセス検出** | 初期は `companyFilter` 規約 + isolation テストで十分 | scoped テーブルが 5 を超える / scoping bug が 1 度でも ship した時 |
+
+## Consequences
+
+### Positive
+
+- **課金境界との整合**: データが `company_id` で分離されるので、ADR-009 が定めた「課金単位 = 事業所」に対し、本体データも機械的に同単位で集計・分離できる。
+- **IDOR の攻撃面が構造的に消える**: D3 の 3 重閉じにより「付け忘れ / 取り違え / パラメータ injection」が型 + 境界 + session 導出で塞がる。
+- **将来テーブルが従う pattern が確立**: `CompanyContext` + `companyFilter` + isolation テスト + `runScopedService` のセットが、新規 company-scoped テーブルの追加手順を予測可能にする。
+- **RPC 増加なし**: companyId source を `react.cache` 済 getSession 一本に統一 (D8) し、`requireCompany` (page) と `runScopedService` (data) が同 cache を共有。
+
+### Negative / トレードオフ
+
+| トレードオフ | 緩和策 |
+|---|---|
+| `CompanyContext` 方式は fail-open (WHERE 付け忘れが型で防げない) | D4 (`companyFilter` 規約 + テーブル別 isolation テスト必須) |
+| SDK upgrade 漏れで companyId が永遠に来ない | Phase 0 をブロッカーとして先行。`SessionData.companyId` 型可視 + Network tab 確認を AC 化 |
+| cross-DB 論理参照 (FK 無し) で本体 company_id と auth company.id の整合が崩れうる | D9 (FK 不可は受容、整合は「scoping を漏らさない」規律 + isolation テストで担保)。orphan company_id は本番前 backfill + signup フロー (ADR-009) で発生しない設計。ただし auth 側 company hard delete (Phase E+ GDPR) 時の本体 orphan は未解決 — Phase E+ の company 削除設計で削除伝播 (event/バッチ cleanup) として扱う (DA #6) |
+| dev DB の ad-hoc 行が NULL のまま not null 化に失敗 | D9 (nullable→placeholder→not null の冪等 3 段)。not null 化前に NULL 0 件を SQL 確認。test DB は factory が company_id を set するため対象外 |
+| scoped/非 scoped runtime 経路の混在 (`runService` / `runScopedService`) | D3 (型で取り違え不能。scoped Service は `runService` に渡すとコンパイルエラー) |
+| 行 scope だけでは mutation 入力 FK / list-all を塞げない (MECE CR1/CR2) | D1 (list/aggregate も `companyFilter`) + D2 (create/update の customerId 自社帰属検証) + D6 (update/delete も 404) |
+| scoping がドメインルールでなく規律 (DI + query helper) 依存 = ドメイン貧血寄り (review-design DDD) | 受容 (`effect-patterns.md` の Repository 不要・Service が drizzle row 直返し方針の帰結)。**非目標**: customer/invoice を Effect.Schema/Data.case のドメイン Entity に昇格させない。規律は閉じ1 の型番兵 + isolation テスト + `companyFilter` SSOT で機械検出に格上げ |
+| `companyFilter` を 3 Service・14 query に手で AND する Shotgun Surgery (review-design anti-pattern) | 同一レイヤー (`app/services/`) に閉じる + `companyFilter` 単一入口で grep 可能 + isolation テスト必須 + `from(<scoped table>)` に `companyFilter` 無しを検出する lint を Phase 1 で導入 |
+
+### セキュリティ観点
+
+- **IDOR 防御 = 3 重 (D3)**: 型 (`CompanyContext` in R) + 境界 (companyId 引数なし) + session 導出 (パラメータ injection 不能)。
+- **3 重閉じの適用範囲 (MECE CR1/CR2)**: 出力行 scope だけでは mutation 入力 FK (`customerId`) と無 scope な list/aggregate (`findAll`/join 集計) を塞げない。詳細と対応は D3「3 重閉じが守らない範囲」を参照。
+- **存在隠蔽 (D6)**: cross-company は 404、id は UUID でグローバル一意 (D7) なので列挙攻撃不能。
+- **backstop (D4)**: `companyFilter` 規約 + isolation テストで「付け忘れ」を検出。RLS は再評価トリガー時に defense-in-depth として追加余地。
+
+## Implementation Roadmap
+
+Phase は手動 QA できる end-to-end 単位で分割 (ADR-009 流)。
+
+### Phase 0: SDK upgrade (前提・極小 PR)
+
+- [ ] `package.json` の `@taimei-code/auth-client` を `^1.0.0` → `1.1.0` (**caret なし exact pin** — auth 側の `last_used_company_id` 意味変更を意図せず取り込まないため、DA #4) に上げ `bun install`。SDK contract test を CI 常時実行 (Phase 0 単発でなく)
+- [ ] `SessionData.companyId` / `currentCompanyName` / `currentCompanyRole` 型が consumer で見えることを確認
+- [ ] `/api/auth/get-session` レスポンスに `companyId` が乗ることを Network tab / curl で確認
+- **AC**: SDK contract test 緑 + `bun tsc --noEmit` で companyId 型可視
+
+### Phase 1: scoping 機構確立 + invoices / customers / revenue + dashboard (本丸)
+
+`company_id` 列が無いと `companyFilter` がコンパイルできないため schema + 機構 + 最初のテーブルが co-land。review surface が大きければ「schema 追加 PR」と「scoping 適用 PR」に 2 分割可。
+
+- [ ] `db/drizzle/schema.ts` の `customers` / `invoices` / `revenue` に `company_id varchar(32)` を **nullable で追加** + `company_id` index (必須、DA #5)。**NOT NULL 化 + `revenue` unique `(company_id, month)` 変更は別 PR** (新アプリデプロイ後 = expand-contract、デプロイ順序 D-1)
+- [ ] `bunx drizzle-kit generate` + 3 段 backfill SQL (D9、本番行の backfill 手順含む)
+- [ ] cross-company write 試行の構造化ログ (試行 companyId / 対象 id / 経路) を実装 (**Required**、DA D-3。fail-open の本番検知系)
+- [ ] `app/services/company-context.ts` (`CompanyContext` Effect.Tag)。companyId の供給元は **session の単一 companyId** と定義 (複数 company 所属は ADR-009 の current company で解決済、本体は単一値を受領、MECE IM6)
+- [ ] `db/scoped.ts` (`companyFilter` SSOT)
+- [ ] `app/services/index.ts`: `makeNextRuntime` を runtime 共有 export に変更 + `runScopedService` 追加 (companyId は `resolveCompanyIdOrRedirect` 経由)。**`AllScopedServices = Layer.Layer.Success<typeof Live>` 導出 + `_NoCompanyContextInLive` 番兵で閉じ1 を型固定 → `bun tsc --noEmit` で成立確認** (review-design 収束指摘、最重要)
+- [ ] `app/lib/auth-guard.ts` に `resolveCompanyIdOrRedirect()` (redirect/companyId 導出 SSOT、未認証→/auth・未選択→signup/company の分岐) + `requireCompany()` (薄い wrapper) + `buildCompanySignupUrl()`
+- [ ] `InvoiceService` / `CustomerService` / `DashboardService` の全 query を scoped 化:
+  - select は `companyFilter` を AND、insert は companyId を context から set
+  - **`update` / `delete` も `companyFilter` を AND** し他社 id は 404 + rows affected=0 (CR1)
+  - **`create` / `update` で `customerId` の自社帰属を検証** (グローバル FK 経由の cross-company 注入を防ぐ、CR1)
+  - **`CustomerService.findAll` を `companyFilter` 経由に** (invoice 作成 dropdown のソース、CR2)。dashboard 等の全 list/aggregate 経路を棚卸し (T1)
+  - **`fetchFiltered` の `customers × invoices` leftJoin に invoices 側 `companyFilter` を AND** (集計金額 leak 防止、IM1)
+- [ ] `app/lib/data.ts` / `app/lib/actions.ts` の該当関数を `runScopedService` 経由に
+- [ ] `app/dashboard/layout.tsx` を `requireCompany` に
+- [ ] **テスト基盤を net-new 整備 (IM2)**: invoice / customer / revenue factory を新規作成 (現状 `factories` は `user` のみ) し company_id を必須 set + `effect-test-helpers` の `createTestServiceLayer` に `CompanyContext` を注入 (固定 companyId、未注入だと scoped 化で既存テストもコンパイル不能)
+- [ ] invoices / customers / revenue の isolation テスト (select に加え **update/delete の他社行不可視・create の他社 customerId 拒否・findAll の自社限定** を必須化、CR1/CR2)
+- [ ] isolation テストで **集計 method の金額アサーション** (`fetchCardData` / `fetchRevenue` / `fetchFiltered` の `totalPaid`/`totalPending` 等が他社金額を加算しない) を必須化 (review-design anti-pattern: select 存在確認だけでは aggregate/join leak を取り逃す)
+- [ ] `from(invoices)` / `from(customers)` / `from(revenue)` に `companyFilter` 参照が無い query を検出する lint (ast-grep) を導入 (Shotgun Surgery backstop の前倒し、review-design)
+- **QA**: 2 社で dashboard 完全分離 (overview チャート / 請求書一覧 / 顧客一覧)、他社 invoice id 直打ち → 404、事業所未選択 user → `/auth/signup/company` redirect、**他社 invoice id で update/delete → 404 + 他社行不変**、**他社 customerId で create → 拒否**、**他社 customer が一覧/dropdown に出ない**、**revenue unique が (company_id, month) のみ**
+
+### Phase 2: tags / tags2 scoped (残テーブル)
+
+- [ ] `tags` / `tags2` に `company_id` + index + backfill
+- [ ] `Tag2Service` を scoped 化
+- [ ] tags / tags2 の isolation テスト
+- **QA**: タグ辞書が社ごとに分離
+
+### デプロイ順序・本番運用 (review-design DA、fatal 3 件反映)
+
+**前提 (DA が実機確認)**: migration は `drizzle/**` の main push で `.github/workflows/drizzle-migrate-deploy.yml` が **自動・即・本番適用** する独立 workflow。アプリ本体デプロイは別経路・別タイミング = schema とアプリのアトミック切替は不可能。observability は現状 `console.error` のみ。
+
+**D-1. expand-contract デプロイ順序 (NOT NULL とアプリの非アトミック切替対策)**: `company_id NOT NULL` 化がアプリより先に本番適用されると、`companyId` を書かない旧アプリの INSERT が NOT NULL violation で全 invoice 作成 500 になる。順序を固定する:
+1. `company_id` を **nullable で追加** する migration を push (自動適用)
+2. 既存行を backfill (本番に実行があれば placeholder、無ければ no-op)
+3. `companyId` を INSERT/UPDATE に書く **新アプリコードをデプロイ**
+4. 全行 backfill 確認後、**NOT NULL 化 migration を別 PR で** push
+- → **NOT NULL 化と `revenue` unique 変更は Phase 1 本体と別 PR に切り出す** (drizzle 自動適用が手順 3 を飛ばすのを防ぐ)。
+- 本番 DB の既存行 backfill 手順 (リリース時点の本番行有無の確認 SQL + placeholder) を migration に含める (D9 は dev/staging のみ論じていたので本番分を補う)。
+
+**D-2. 本番リリースは Phase 1 + Phase 2 を束ねる (tag leak 窓を本番に出さない)**: 開発・QA 単位の Phase 分割と本番リリース単位を分離する。`_invoicesTotags` の leak 窓 (D1/IM5) は dev/staging では許容するが、**本番には Phase 2 (tags scoped) 完了まで出さない** — 本番リリースは Phase 1+2 を同一デプロイにまとめる (feature flag 基盤が無いためリリース束ねで対応)。
+
+**D-3. fail-open の検知系は Required + rollback 手順**: fail-open 設計 (D4) で本番 leak が起きても気づけないのは設計矛盾。
+- **検知 (Required)**: cross-company write 試行 (他社 customerId / 他社 id mutation) の構造化ログ (試行 companyId / 対象 id / 経路) を **Phase 1 必須**に格上げ (IM7 を Important → Required)。observability が console.error のみでも後で集計可能な構造で出す。
+- **rollback**: NOT NULL / unique 変更は forward migration で「アプリだけ rollback」が効かない (新 schema 上で旧アプリが violation)。drizzle-kit に down が無いため revert 用 nullable 戻し SQL を `drizzle/manual/` に用意し、**「rollback は forward-only (戻し migration を別 push)」を運用方針に固定**。
+- **RLS 前倒しトリガー**: 「**最初の実顧客受入前**に RLS を defense-in-depth で入れる」を時系列トリガーに追加 (『pen-test 指摘後』= 漏れた後では遅い)。
+
+### Phase E+ (将来トリガー時)
+
+- RLS を defense-in-depth で追加 (Alternatives Considered のトリガー: 本番課金 / 実顧客企業 / pen-test 指摘)
+- ast-grep/lint で未 scoped 直アクセス検出 (トリガー: scoped テーブル 5 超 / scoping bug ship)
+- 社内連番 display-id (D7、別列 + `(company_id, no)` 複合一意)
+- admin 代理閲覧 / background job 用の明示 companyId 経路 (監査ログ必須)
+- **RBAC / authorization 層** (role 別の操作制限、例: MEMBER は invoice 削除不可): `CompanyContext` を拡張せず別層 (`AuthorizationContext` + permission チェック) を新設。freee の AclKit / sekisyo 権限セット型 (Sources「freee 参考調査」)。トリガー: role 別操作制限が要件化した時
+- **invoice immutability (顧客情報スナップショット)**: 現状 invoice は customer を FK 参照するのみで発行時スナップショットを持たないため、customer 編集が過去 invoice の表示に遡及する。freee は「請求書と取引先マスタの分離」で発行時ワンタイムコピーに変更済 (Sources「freee 参考調査」)。本 ADR の scoping とは別軸なので別 ADR 候補。トリガー: 本番で過去 invoice の改変懸念が顕在化した時
+
+### テスト戦略 (backstop の実体)
+
+`.claude/rules/testing-strategy.md` の `dbEffect` (withRollback + Factory) に乗せ、テーブル別 isolation テストを必須化:
+
+```ts
+dbEffect("InvoiceService は他社 invoice を返さない", ({ factory: f }) =>
+  Effect.gen(function* () {
+    const a = f.invoice.create({ companyId: "cmp_aaa" });
+    const b = f.invoice.create({ companyId: "cmp_bbb" });
+    const svc = yield* InvoiceService;
+    const res = yield* Effect.either(svc.findById(b.id)); // A context で B の id
+    expect(Either.isLeft(res)).toBe(true); // InvoiceNotFound (404 相当)
+  }).pipe(Effect.provide(CompanyContext.of({ companyId: "cmp_aaa", role: "OWNER" }))),
+);
+```
+
+各 scoped テーブルにつき select / update / delete の cross-company 不可視 + create の company_id 自動付与を検証。
+
+## Sources
+
+### 一次資料 (taimei 本体)
+
+- `db/drizzle/schema.ts:15-111` — 既存ドメインテーブル (company_id なし、単一列 UUID PK)
+- `app/services/invoice-service.ts` — 無 scope な query (IDOR 面)
+- `app/services/index.ts:59-81` — `Live` runtime / `runService` / `makeNextRuntime`
+- `app/lib/auth-guard.ts:28-48` — SDK guard 経由 `getSession()` / `requireSession()`
+- `app/lib/data.ts` / `app/lib/actions.ts` — data fetch / mutation 呼出側
+- `proxy.ts:38-66` — Next middleware (cookie 存在チェックのみ)
+- `app/services/__tests__/db/effect-test-helpers.ts` / `factories` — `dbEffect` + factory (isolation テスト基盤)
+- `node_modules/@taimei-code/auth-client/dist/types.d.ts:2-17` — `SessionData` (companyId 未提供、Phase 0 ブロッカーの根拠)
+- `package.json:42` — `@taimei-code/auth-client: ^1.0.0`
+
+### プロジェクト規約
+
+- `.claude/rules/effect-patterns.md` — Service が PgDrizzle 直接使用 / Effect.Tag vs Effect.Service / Layer 共有変数
+- `.claude/rules/testing-strategy.md` — `dbEffect` / isolation テスト
+- `.claude/rules/external-library-integration.md` — DIP パターン
+
+### freee 参考調査 (社内リソース、2026-05-26)
+
+customers の帰属モデル (案 A = per-company / company-private) と snapshot 発見の根拠:
+
+- 顧客/取引先マスタ構造の現行例 (Slack #pangea-log、PKG-1056 PR by github bot): `useFetchCustomers`(顧客マスタ) / `useFetchPartners`(取引先マスタ) / 仕入先マスタ を会計freee API で分離取得。「各APIは事業所スコープで制限されている」= 事業所単位分離
+- 取引先マスタの社横断共有は顧問関係限定 (Jira `VQX-664`「取引先マスタ権限分離」/ `US-6531` / `US-6149` ほか: アドバイザー事業所 ↔ 顧問先の権限自動付与) — taimei MVP 除外概念 (ADR-009 D3)
+- 請求書とマスタの分離設計 (Confluence「2019?請求書と取引先マスタを分離 - plan」id 584843535): 取引先マスタを請求書から分離し、発行時に取引先情報をワンタイムコピー。過去 invoice がマスタ編集で遡及変更されないようにする → 本 ADR の invoice immutability 別 ADR 候補 (Phase E+) の根拠
+
+`CompanyContext` を companyId のみにする (D2) / authorization を別層にする根拠:
+
+- 認可は session/membership と別の専用層 (Slack #pj-従業員として利用する取引先の権限制御 by maho-togashi、取引先 controller 実例): OAuth スコープ (アプリ単位) → 403 と AclKit 権限 (ユーザーの事業所内ロール=管理者/一般/閲覧者) → 401 の 2 層。membership 由来 role は AclKit 層で消費される
+- membership が持つのは「属性」(従業員 / アドバイザー) で role(権限セット)とは別概念 (Slack #team-iam-acm by hiroki-yoshida)
+- RBAC 実装パターン (Slack #team-hr_integrated_master、freee-accounts PR #13451): `sekisyo.yml` 権限定義 + `PrivilegeControlService#xxx:read/:write` を controller `before_action` でチェック → 403。session 非依存の独立層
+- 認可バイパスの fail-open 事例 (Jira `VULNS-389` ACL マッピング不足 / `VULNS-348` permission.yaml 設定不足 / `ZUNDA-2138` 他社履歴アクセス遮断) → 本 ADR の backstop (D4 isolation テスト + helper) が狙う失敗モードと一致
+
+## Related ADRs
+
+> plans/taimei の `ADR-NNN` 系列は taimei 全体 (taimei-auth 含む) のアーキ決定ログ。本 repo の `docs/adr/` は app.taimei 個別の決定。
+
+- **taimei-auth 事業所概念 ADR (plans `ADR-009`)** — 本 ADR の trigger。taimei-auth が `company` / `membership` と SDK `companyId` を提供。本 ADR はその `companyId` を本体ドメインデータの scoping に使う consumer 側の対。§2.1 D5 / Q12 / §3.3 / §12 を本文で参照。
+- **taimei-auth account 管理集約 ADR (plans `ADR-008`)** — `/account` を taimei-auth に集約した上に事業所概念を載せた前提。
+- **taimei-auth SDK 統一 / framework 中立化 ADR (plans `ADR-005` / `ADR-007`)** — 本 ADR が依存する `getSession()` SDK 経路の設計元。
+- **`docs/adr/0001-supply-chain-hardening.md`** — 本 repo の既存 ADR (系列の先行例)。
+
+---
+
+## 品質検証
+
+- AC: 6観点 (主軸5 permission/auth_state/data_compat/caller/contract + observability) × 必須3カテゴリ + 非影響確認 4件 = 22項目定義済み → `docs/adr/0002-company-data-scoping.analysis.md`
+- 技術リスク: 4件特定済み → `docs/adr/0002-company-data-scoping.analysis.md`
+- MECE判定: 要修正（Critical 2件）/ ACカバレッジ 17/30 (うち[MECE追加] 8件) / 漏れ 4件 / 重複 2件 → `docs/adr/0002-company-data-scoping.analysis.md`
+- review-design: 構造 reviewer 4 (fatal 0) + DA (fatal 3 → 全解消)、本文 D2/D3/D5/D6/D8/D9 + Roadmap デプロイ順序節に反映済
+
+---
+
+## 実装準備
+
+> 新規セッションで実装する前提の段取り document。AC / MECE / review-design の結論は本文と `docs/adr/0002-company-data-scoping.analysis.md` を SSOT とする。
+
+### ブランチ戦略
+
+- base: `main`。各 PR は `feature/company-scoping-<topic>` で切る (stacked。下流は上流 PR を base にする)。
+- **デプロイ順序の制約 (expand-contract)**: full 手順は §「デプロイ順序・本番運用」D-1 を参照。要点は **NOT NULL 化 + revenue unique 変更を別 PR (PR-5) に切り出し、サービス適用 PR (PR-3/4) の本番デプロイ後に push** する (migration は `drizzle/**` push で自動・即・本番適用されるため)。
+- **本番リリース束ね (DA D-2)**: dev/staging は PR 段階マージ可。**本番リリースは PR-1〜6 を束ねて出す** (Phase 1 単独本番は `_invoicesTotags` の tag leak 窓を開けるため不可)。
+
+### PR分割計画
+
+| PR | スコープ | 主ファイル | 依存 | 備考 |
+|----|----------|-----------|------|------|
+| **PR-0** (Phase 0) | SDK `1.1.0` exact pin + contract test (CI 常時) | `package.json` / `bun.lock` / contract test | — | **blocking precondition**。`getSession().companyId` 型可視 + `/api/auth/get-session` に companyId を curl/Network 確認 |
+| **PR-1** | schema: 全 scoped 表に `company_id varchar(32)` **nullable** + index 追加 + backfill SQL (`drizzle/manual/`) | `db/drizzle/schema.ts` / `drizzle/NNNN_*.sql` / `drizzle/manual/*.sql` | — | NOT NULL/unique 変更は含めない (PR-5 へ) |
+| **PR-2** | scoping 機構 + テスト基盤 | `app/services/company-context.ts` / `db/scoped.ts` / `app/services/index.ts` (makeNextRuntime runtime 共有 + runScopedService + `AllScopedServices` 導出 + `_NoCompanyContextInLive` 番兵) / `app/lib/auth-guard.ts` (resolveCompanyIdOrRedirect + requireCompany + buildCompanySignupUrl) / 各 factory (net-new) + effect-test-helpers (CompanyContext) | PR-1 | `bun tsc --noEmit` で閉じ1 成立確認 |
+| **PR-3** | invoice/customer scoping + 呼出側 + isolation テスト | `invoice-service.ts` (findById/update/delete に companyFilter、create/update に customerId 自社帰属検証) / `customer-service.ts` (findAll scope + fetchFiltered join companyFilter) / `data.ts` / `actions.ts` (runScopedService) / cross-company write 試行ログ / isolation テスト | PR-2 | CR1/CR2/IM1 |
+| **PR-4** | dashboard scoping + layout | `dashboard-service.ts` (revenue/cards/latest scoped) / `app/dashboard/layout.tsx` (requireCompany) / isolation テスト (集計金額アサート) | PR-2 | overview leak 防止 |
+| **PR-5** | **NOT NULL 化 + revenue unique `(company_id, month)`** | `drizzle/NNNN_*.sql` | PR-3/4 **本番デプロイ後** | expand-contract の contract 段。別 PR 必須 (D-1) |
+| **PR-6** (Phase 2) | tags/tags2 scoped | `schema.ts` (tags company_id) / `tag2-service.ts` / isolation テスト | PR-2 | 本番は PR-1〜6 束ねリリース (D-2) |
+
+PR ガイドライン (≤2 commits / ≤5 files) 超過は PR-2 (機構 + テスト基盤が密結合) のみ許容。review surface が大きければ PR-2 を「機構」と「テスト基盤」に 2 分割可。
+
+### 手動QA手順 (Chrome DevTools MCP)
+
+**環境**: `http://app.taimei-code.local:3001` (dev compose、taimei-auth → taimei の順。Magic Link は `docker logs <auth-service> | grep "Magic Link"`)。**2 社 (company A / B) のアカウント + 各社の invoice/customer 実 UUID** が前提 (IDOR 直打ち用、実値は QA 実行時にユーザー確認)。権限ロール差は不要 (本 ADR は RBAC 非対象)。
+
+手動カバー (UI/redirect 実挙動、`testing-strategy.md` の「自動で書かない」領域):
+- **QA-H-01** A 社 invoice のみ一覧 (B 社不含、別タブ B で対比) / **QA-H-02** 選択済 → redirect なし scoped 描画
+- **QA-E-01** 他社 invoice id 直打ち `/dashboard/invoices/<B社id>/edit` → **404** (not-found ページ、403 でない) / **QA-E-02** companyId undefined → 302 → `/auth/signup/company` / **QA-E-06 (=QA-M-06)** session 無効 → SDK guard null → `/auth`
+- **QA-D-01 (=QA-M-04)** create dropdown を `evaluate_script` で迂回し B 社 customerId を POST → 作成失敗 (automation 不安定時は localhost curl で Server Action POST 併用) / **QA-D-04** 2 タブ別 company → 各 request 正しい companyId / **QA-D-05** 新規 signup membership 0 → redirect
+- **QA-M-01** create dropdown が自社 customer のみ (B 社顧客名が出ない) / **QA-M-05** (customers 一覧 UI 実装後) 集計 totalPaid に他社金額混入なし ※現状 `/dashboard/customers` はスタブ、UI 実装後に実施
+- **QA-R-01** Magic Link 送信不変 / **QA-R-02** after-sign 着地不変 / **QA-R-03** 未認証 → `/auth` 維持
+
+> 他社 update/delete (QA-M-03) は UI 導線が存在しない (一覧に出ず edit に入れない) ため「到達不能」を手動確認 + rows=0 の確実性は自動 QA。
+
+### 自動QA (Vitest、テストコード仕様)
+
+**前提 (全 isolation テストのブロッカー、PR-2)**: factory net-new (`customer`/`invoice`/`revenue`、companyId は **デフォルト無し=override 必須**) + `effect-test-helpers` は CompanyContext を**注入しない**設計 (各テストが `.pipe(Effect.provide(CompanyContext.of({ companyId, role })))`、provide 漏れがコンパイルエラー=backstop)。
+
+自動カバー (dbEffect isolation / 型 / migration SQL):
+- **QA-E-04 ★** (閉じ1): `index.ts` の `_NoCompanyContextInLive` 番兵 + `bun tsc --noEmit` 緑 + `@ts-expect-error` で「scoped Service を runService に渡すと型エラー」を negative type test 固定。Live に CompanyContext を故意 merge して tsc が落ちることを 1 度確認 (Phase 1 手動チェック)
+- **QA-E-01 / QA-H-01 / QA-H-04**: `invoice-service.test.ts` — 2 社 seed、A context で B invoice findById → `InvoiceNotFound`、fetchFiltered は自社のみ
+- **QA-M-03 ★** (CR1): A context で B invoice を update/delete → `InvoiceNotFound` かつ `tx` 直 select で **B 行が不変** (rows=0 実証)
+- **QA-M-04 / QA-D-01 ★** (CR1): A context で B 社 customerId create → 拒否 + A 社 invoice 行が作られない (cross-company 注入なし)。対の正常系: A 社 customerId なら companyId=A 自動付与
+- **QA-M-01** (CR2): `customer-service.test.ts` — findAll が自社のみ / **QA-M-05** (IM1): 同名 customer を両社に置き fetchFiltered の `totalPaid===自社分のみ` (leftJoin invoices の companyFilter AND を金額アサート) + `dashboard-service.test.ts` の fetchCardData/fetchRevenue
+- **QA-H-03 / QA-M-02 / QA-E-03 / QA-D-03**: `db/company-scoping-migration.test.ts` — `information_schema`/`pg_indexes`/`pg_constraint` で NOT NULL+index+backfill (NULL 0) / revenue unique が `(company_id, month)` のみ / 破壊的 DDL は一時テーブルで検証
+- **QA-M-08** (IM7): create 拒否時に構造化ログ (試行 companyId / 対象 id / 経路) が console.error spy で記録される
+- **QA-M-07** (Phase 2): `tag2-service.test.ts` — Phase 1 は `dbEffect.skip` で leak 窓を明示、PR-6 で有効化
+- 非影響: QA-R-01/R-04 は既存 `auth-service.test.ts` pass + `bun tsc --noEmit` 緑 + `bun run test:db` 全パス
+
+**新規/追記テストファイル**: `invoice-service.test.ts` / `customer-service.test.ts` / `dashboard-service.test.ts` (追記) / `db/company-scoping-migration.test.ts` / `no-company-context-in-live.test-d.ts` / `tag2-service.test.ts` (新規) / `factories/index.ts` / `db/effect-test-helpers.ts` (基盤修正)。
+
+### QAカバレッジ (31 QA-ID)
+
+- 自動: QA-E-04(★型) / QA-E-01 / QA-H-01,03,04 / QA-M-01,02,03★,04★,05,07,08 / QA-D-01,03 / QA-R-01,04 ＝ 16
+- 手動: QA-H-02 / QA-E-02,06 / QA-D-02,04,05,06 / QA-M-06,09 / QA-R-02,03 / QA-M-01,05 の UI 部分 ＝ 11
+- 両方 (Service=auto / 画面=manual): QA-H-04,05 / QA-D-01(=M-04) / QA-M-03 の到達不能確認 ＝ 4
+- 全 31 QA-ID が手動・自動いずれか (or 両方) でカバー。0 件カテゴリなし。

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@react-email/components": "^1.0.2",
     "@sentry/nextjs": "^9",
     "@tailwindcss/forms": "^0.5.7",
-    "@taimei-code/auth-client": "^1.0.0",
+    "@taimei-code/auth-client": "1.1.0",
     "@vercel/blob": "^1.0.0",
     "autoprefixer": "10.4.19",
     "bcrypt": "^5.1.1",


### PR DESCRIPTION
## やったこと

`@taimei-code/auth-client` を `1.1.0` に exact pin し、SDK の `companyId` 型契約を CI で守る型レベルテストを追加した。あわせて本シリーズの設計文書 (ADR-0002 / CONTEXT.md) を追加した。

## なぜやるのか

`getSession().companyId` が後続の事業所データ scoping (PR-1 以降) の唯一の company source であり、それを提供する SDK 1.1.0 への upgrade が全 Phase の前提になるため。

## 動作確認結果

`bun tsc --noEmit` で `companyId` 型可視、`bun run test:db` 全 77 件緑 (新規 contract test 含む)。

## 設計判断

`^` を外した exact pin にした。auth 側で `last_used_company_id` の意味が変わった際に minor/patch 自動追従で意図せず取り込むのを避け、upgrade を必ず明示の変更として扱うため。

実際にインストールした 1.1.0 の `SessionData` は `companyId?: string` のみを提供し、事前想定にあった会社名・ロールのフィールドは持たない。この観測に基づき、後続 PR の company context は companyId 単一値で組む (ロールは scoping ではなく認可の関心事であり別層に置く)。

contract test は auth-guard を経由せず SDK の型のみを import する。auth-guard を import すると server-only ガードと ConnectRPC client の初期化が走り、型契約の検証に不要な runtime 依存を持ち込むため。型 assertion は `bun tsc --noEmit` (CI 常時) で評価され、SDK が `companyId` を落とした退行を PR でブロックする。

## やらなかったこと

事業所未選択 user での `/api/auth/get-session` の runtime 確認は、ログイン済の 2 社セッションを要するため、その環境を組む後続 PR の QA でまとめて行う。

## レビューしてほしい観点

exact pin (semver 自動追従を切る) の是非。

## Revert 手順

このブランチの revert で `^1.0.0` に戻る。schema 変更を含まないため DB 影響なし。
