### PR TITLE
feat(db): ドメイン 3 テーブルに company_id を nullable 追加 (ADR-0002 PR-1)

### DIFF
--- a/db/drizzle/schema.ts
+++ b/db/drizzle/schema.ts
@@ -12,12 +12,20 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
-export const customers = pgTable("customers", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  name: varchar({ length: 255 }).notNull(),
-  email: varchar({ length: 255 }).notNull(),
-  imageUrl: varchar("image_url", { length: 255 }).notNull(),
-});
+export const customers = pgTable(
+  "customers",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    name: varchar({ length: 255 }).notNull(),
+    email: varchar({ length: 255 }).notNull(),
+    imageUrl: varchar("image_url", { length: 255 }).notNull(),
+    // company_id は auth (taimei-auth) の company.id (cmp_<nanoid24>) への論理参照。
+    // cross-DB のため FK は張らない。nullable で追加し NOT NULL 化は別 migration (expand-contract)。
+    // 設計詳細: docs/adr/0002-company-data-scoping.md (D9)
+    companyId: varchar("company_id", { length: 32 }),
+  },
+  (table) => [index("customers_company_id_idx").on(table.companyId)],
+);
 
 export const tags2 = pgTable("tags2", {
   id: uuid().defaultRandom().primaryKey().notNull(),
@@ -49,6 +57,8 @@ export const invoices = pgTable(
     updatedAt: timestamp("updated_at", { precision: 6, mode: "string" })
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
+    // auth company.id への論理参照 (FK なし)。詳細は customers.companyId と docs/adr/0002 を参照。
+    companyId: varchar("company_id", { length: 32 }),
   },
   (table) => [
     foreignKey({
@@ -58,6 +68,7 @@ export const invoices = pgTable(
     })
       .onUpdate("cascade")
       .onDelete("cascade"),
+    index("invoices_company_id_idx").on(table.companyId),
   ],
 );
 
@@ -72,12 +83,16 @@ export const revenue = pgTable(
     updatedAt: timestamp("updated_at", { precision: 6, mode: "string" })
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
+    // auth company.id への論理参照 (FK なし)。詳細は customers.companyId と docs/adr/0002 を参照。
+    // month 単独 unique は別 migration で (company_id, month) に変更する (社ごと同月行を許可)。
+    companyId: varchar("company_id", { length: 32 }),
   },
   (table) => [
     uniqueIndex("revenue_month_key").using(
       "btree",
       table.month.asc().nullsLast().op("text_ops"),
     ),
+    index("revenue_company_id_idx").on(table.companyId),
   ],
 );
 

--- a/drizzle/0003_funny_exiles.sql
+++ b/drizzle/0003_funny_exiles.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "customers" ADD COLUMN "company_id" varchar(32);--> statement-breakpoint
+ALTER TABLE "invoices" ADD COLUMN "company_id" varchar(32);--> statement-breakpoint
+ALTER TABLE "revenue" ADD COLUMN "company_id" varchar(32);--> statement-breakpoint
+CREATE INDEX "customers_company_id_idx" ON "customers" USING btree ("company_id");--> statement-breakpoint
+CREATE INDEX "invoices_company_id_idx" ON "invoices" USING btree ("company_id");--> statement-breakpoint
+CREATE INDEX "revenue_company_id_idx" ON "revenue" USING btree ("company_id");

--- a/drizzle/manual/0003_company_id_backfill.sql
+++ b/drizzle/manual/0003_company_id_backfill.sql
@@ -1,0 +1,14 @@
+-- 既存行の company_id backfill。設計詳細: docs/adr/0002-company-data-scoping.md (D9)。
+--
+-- drizzle/manual/ は drizzle-kit の journal 管理外で、`drizzle-kit migrate` では適用されない。
+-- リリース時に ops が手動実行する。NOT NULL 化 migration の前に必ず流すこと
+-- (NOT NULL を先に適用すると既存 NULL 行で制約違反になり migration が abort するため)。
+--
+-- placeholder は auth の実 company.id に結合しない固定値にする (cross-DB 結合を避ける)。
+-- 意味あるデータは signup フロー / factory 由来であり、この backfill は
+-- 「リリース時点で残っていた既存行を NOT NULL 化可能にする」ためだけのもの。
+-- 冪等: company_id IS NULL の行だけを対象にするため複数回流しても安全 (2 回目以降は 0 行)。
+
+UPDATE "customers" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;
+UPDATE "invoices" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;
+UPDATE "revenue" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,379 @@
+{
+  "id": "2a27fc1b-8c47-47e5-a085-b2eff4f62f4a",
+  "prevId": "e67b4a2e-0176-4134-b65b-0c819beced0f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_company_id_idx": {
+          "name": "customers_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoices_company_id_idx": {
+          "name": "invoices_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_customer_id_fkey": {
+          "name": "invoices_customer_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": ["customer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._invoicesTotags": {
+      "name": "_invoicesTotags",
+      "schema": "",
+      "columns": {
+        "A": {
+          "name": "A",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "B": {
+          "name": "B",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_invoicesTotags_B_index": {
+          "name": "_invoicesTotags_B_index",
+          "columns": [
+            {
+              "expression": "B",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_invoicesTotags_A_fkey": {
+          "name": "_invoicesTotags_A_fkey",
+          "tableFrom": "_invoicesTotags",
+          "tableTo": "invoices",
+          "columnsFrom": ["A"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "_invoicesTotags_B_fkey": {
+          "name": "_invoicesTotags_B_fkey",
+          "tableFrom": "_invoicesTotags",
+          "tableTo": "tags",
+          "columnsFrom": ["B"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "_invoicesTotags_AB_pkey": {
+          "name": "_invoicesTotags_AB_pkey",
+          "columns": ["A", "B"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revenue": {
+      "name": "revenue",
+      "schema": "",
+      "columns": {
+        "month": {
+          "name": "month",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "revenue_month_key": {
+          "name": "revenue_month_key",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "revenue_company_id_idx": {
+          "name": "revenue_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags2": {
+      "name": "tags2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1779529784314,
       "tag": "0002_new_lockjaw",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1779878912291,
+      "tag": "0003_funny_exiles",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## やったこと

`customers` / `invoices` / `revenue` に `company_id varchar(32)` を nullable で追加し、各テーブルに index を張った。既存行向けの冪等 backfill SQL を手動実行用に追加した。

## なぜやるのか

事業所データ scoping (PR-3 以降) が `company_id` 列を前提とするため、まず列だけを後方互換に追加する。

## 動作確認結果

test_db に migration 適用後、既存サービステストを含む全 77 件が緑。

## 設計判断

NOT NULL 化と `revenue` の `(month)` → `(company_id, month)` unique 変更はこの PR に含めず別 PR に分離した。migration は `drizzle/**` の main push で本番に自動適用されるため、`company_id` を書く新アプリのデプロイより先に NOT NULL が本番適用されると、旧アプリの INSERT が制約違反で全失敗する。列追加 (expand) と制約強化 (contract) を別デプロイに分け、間に新アプリのデプロイを挟む。

`company_id` は auth 側 `company.id` への論理参照だが FK は張らない。auth と本体は別 DB で外部キーを張れないため。整合は scoping を漏らさない規律と isolation テスト (後続 PR) で担保する。

backfill SQL は `drizzle/manual/` に置いた。`drizzle-kit migrate` の journal 管理外で本番自動適用の対象にならず、リリース時に ops が NOT NULL 化の前段として手動で流す。`WHERE company_id IS NULL` 限定で冪等。placeholder は auth の実 company に結合しない固定値とし cross-DB 結合を避ける。

## やらなかったこと

`tags` / `tags2` への `company_id` 追加は Phase 2 (後続 PR) に回した。`fetchFiltered` 向けの company_id 前置複合 index も、まずは単一列 index で足り、検索最適化は必要が出てから入れる。

## レビューしてほしい観点

expand-contract の段分けと、本番への自動 migration 適用順序の前提。

## Revert 手順

このブランチの revert で列・index が DROP される。nullable 追加のみで他テーブル・既存行に影響しないため安全に戻せる。
