### PR TITLE
feat(services): 事業所スコープ機構と IDOR backstop の型番兵を追加 (ADR-0002 PR-2)

### DIFF
--- a/app/lib/auth-guard.ts
+++ b/app/lib/auth-guard.ts
@@ -47,5 +47,30 @@ export const requireSession = async ({
   return session;
 };
 
+// 事業所未選択 user の登録先 (taimei-auth web SPA 上)。設計詳細: docs/adr/0002-company-data-scoping.md (D5)。
+// proxy.ts の AUTH_URL 解決と同型で NEXT_PUBLIC_AUTH_URL を base に絶対 URL を組む。
+const AUTH_URL =
+  process.env.NEXT_PUBLIC_AUTH_URL || "https://auth.taimei-code.com";
+
+export const buildCompanySignupUrl = (returnTo = "/dashboard") =>
+  `${AUTH_URL}/auth/signup/company?returnTo=${encodeURIComponent(returnTo)}`;
+
+// redirect + companyId 導出の SSOT。data 層の runScopedService と page 層の requireCompany が共有する。
+// 未認証 (session null) と「認証済・事業所未選択」で redirect 先を分岐する。
+// redirect() は Next の control-flow throw なので、Effect の外 (Next 境界) でしか実行できない。
+export const resolveCompanyIdOrRedirect = async (returnTo = "/dashboard") => {
+  const session = await getSession(); // react.cache 済 (page/data が同 cache を共有)
+  if (!session) redirect(`/auth?callbackUrl=${encodeURIComponent(returnTo)}`);
+  if (!session.companyId) redirect(buildCompanySignupUrl(returnTo));
+  return { companyId: session.companyId, session };
+};
+
+// page レベル UX 用の thin wrapper。data fetch 前に layout で redirect して描画チラつきを防ぎ、
+// nav 表示用に session も返す。security backstop ではない (それは runScopedService 自身)。
+export const requireCompany = async ({ returnTo }: { returnTo: string }) => {
+  const { companyId, session } = await resolveCompanyIdOrRedirect(returnTo);
+  return { ...session, companyId };
+};
+
 // Result enum を consumer (page 等) でも参照可能にする re-export
 export { Result };

--- a/app/services/__tests__/company-scoping-infra.test.ts
+++ b/app/services/__tests__/company-scoping-infra.test.ts
@@ -1,0 +1,65 @@
+import { it } from "@effect/vitest";
+import { eq } from "drizzle-orm";
+import { Effect } from "effect";
+import { expect } from "vitest";
+import { customers, invoices, revenue } from "@/db/drizzle/schema";
+import { CompanyContext } from "../company-context";
+import { dbEffect } from "./db/effect-test-helpers";
+
+// PR-2 の機構基盤テスト。scoping 適用 (companyFilter を WHERE に入れる) は PR-3/4 で、
+// ここでは factory が company_id を持つ行を生成できること + CompanyContext 注入を検証する。
+
+dbEffect(
+  "factory が company_id を持つ customer/invoice/revenue を生成・永続化する",
+  ({ factory: f, tx }) =>
+    Effect.gen(function* () {
+      const customer = yield* Effect.promise(() =>
+        f.customer.create({ companyId: "cmp_aaa" }),
+      );
+      expect(customer.companyId).toBe("cmp_aaa");
+
+      // customerId 明示時は customer を関連生成せず渡した値を使う。
+      const invoice = yield* Effect.promise(() =>
+        f.invoice.create({ companyId: "cmp_aaa", customerId: customer.id }),
+      );
+      expect(invoice.companyId).toBe("cmp_aaa");
+      expect(invoice.customerId).toBe(customer.id);
+
+      const rev = yield* Effect.promise(() =>
+        f.revenue.create({ companyId: "cmp_bbb", month: "2601" }),
+      );
+      expect(rev.companyId).toBe("cmp_bbb");
+
+      // DB に company_id が永続化されていることを確認 (列が実在し書き込まれている)。
+      const persisted = yield* Effect.promise(() =>
+        tx
+          .select({ id: customers.id, companyId: customers.companyId })
+          .from(customers)
+          .where(eq(customers.id, customer.id)),
+      );
+      expect(persisted[0]?.companyId).toBe("cmp_aaa");
+
+      const persistedInvoice = yield* Effect.promise(() =>
+        tx
+          .select({ companyId: invoices.companyId })
+          .from(invoices)
+          .where(eq(invoices.id, invoice.id)),
+      );
+      expect(persistedInvoice[0]?.companyId).toBe("cmp_aaa");
+
+      const persistedRevenue = yield* Effect.promise(() =>
+        tx
+          .select({ companyId: revenue.companyId })
+          .from(revenue)
+          .where(eq(revenue.month, "2601")),
+      );
+      expect(persistedRevenue[0]?.companyId).toBe("cmp_bbb");
+    }),
+);
+
+it.effect("CompanyContext から注入した companyId を読める", () =>
+  Effect.gen(function* () {
+    const { companyId } = yield* CompanyContext;
+    expect(companyId).toBe("cmp_zzz");
+  }).pipe(Effect.provide(CompanyContext.layer({ companyId: "cmp_zzz" }))),
+);

--- a/app/services/__tests__/factories/index.ts
+++ b/app/services/__tests__/factories/index.ts
@@ -6,6 +6,7 @@ import {
   timestamp,
   uniqueIndex,
 } from "drizzle-orm/pg-core";
+import * as appSchema from "@/db/drizzle/schema";
 
 // user テーブルは auth-service DB に移動済みだが、テストでは taimei DB に
 // 残存する user テーブルに直接書き込む（テスト用の暫定措置）
@@ -34,8 +35,17 @@ const user = pgTable(
 // test-db.ts からも参照するため export
 export const testTableSchema = { user };
 
+// composeFactory は全 factory が同一 Schema 型を共有する必要があるため、
+// アプリスキーマ (customers/invoices/revenue 等) と test 用 user を統合した schema を使う。
+const factorySchema = { ...appSchema, user };
+
+// company_id は sequence ユニークな default にする。設計意図: docs/adr/0002 のテスト戦略。
+// 固定 default だと isolation テストで override 忘れ時に 2 社が同一 company になり誤 pass するが、
+// sequence ユニークなら忘れても context の companyId と不一致 → 0 行 hit で loud に fail する。
+const defaultCompanyId = (sequence: number) => `cmp_factory_${sequence}`;
+
 export const userFactory = defineFactory({
-  schema: testTableSchema,
+  schema: factorySchema,
   table: "user",
   resolver: ({ sequence }) => ({
     id: `test-user-${sequence}`,
@@ -59,6 +69,58 @@ export const userFactory = defineFactory({
   },
 });
 
+export const customerFactory = defineFactory({
+  schema: factorySchema,
+  table: "customers",
+  resolver: ({ sequence }) => ({
+    id: crypto.randomUUID(),
+    name: `Customer ${sequence}`,
+    email: `customer${sequence}@example.com`,
+    imageUrl: `/customers/${sequence}.png`,
+    companyId: defaultCompanyId(sequence),
+  }),
+});
+
+export const invoiceFactory = defineFactory({
+  schema: factorySchema,
+  table: "invoices",
+  // use を withFactory に alias する: `use` で始まる名前だと eslint react-hooks/rules-of-hooks が
+  // React の use フックと誤認するため (実体は drizzle-factory の関連生成関数)。
+  resolver: ({ sequence, use: withFactory }) => ({
+    id: crypto.randomUUID(),
+    amount: 1000 + sequence,
+    status: "pending",
+    date: "2026-01-01",
+    // customerId 未指定時のみ customer を関連生成する (遅延評価)。
+    // 注意: 自動生成 customer は別 sequence の companyId を持ち invoice の companyId と一致しない。
+    // 「自社 customerId で作成成功」等の isolation テストでは customerId を明示すること
+    // (drizzle-factory は resolver field 間で override 値を共有できないため自動継承は不可)。
+    customerId: () =>
+      withFactory(customerFactory)
+        .create()
+        .then((c) => c.id),
+    createdAt: "2026-01-01 00:00:00",
+    updatedAt: "2026-01-01 00:00:00",
+    companyId: defaultCompanyId(sequence),
+  }),
+});
+
+export const revenueFactory = defineFactory({
+  schema: factorySchema,
+  table: "revenue",
+  resolver: ({ sequence }) => ({
+    // month 単独 unique (PR-5 で (company_id, month) 化) のため sequence でユニークにする。
+    month: String(sequence).padStart(4, "0"),
+    revenue: 10000 + sequence,
+    createdAt: "2026-01-01 00:00:00",
+    updatedAt: "2026-01-01 00:00:00",
+    companyId: defaultCompanyId(sequence),
+  }),
+});
+
 export const factory = composeFactory({
   user: userFactory,
+  customer: customerFactory,
+  invoice: invoiceFactory,
+  revenue: revenueFactory,
 });

--- a/app/services/company-context.ts
+++ b/app/services/company-context.ts
@@ -1,0 +1,20 @@
+import { Effect, Layer } from "effect";
+
+// per-request の事業所コンテキスト。設計詳細: docs/adr/0002-company-data-scoping.md (D2)。
+//
+// scoping (どの company のデータか) のみを保持し、authorization (= 何ができるか) は持たない。
+// companyId は認証済 session から境界の内側で導出され、呼出側は値を供給しない (IDOR 防御)。
+// role 別の操作制限が要件化したら CompanyContext を拡張せず別層 (AuthorizationContext) を新設する。
+export interface CompanyContextShape {
+  readonly companyId: string;
+}
+
+// 本番は per-request 注入・テストは固定値注入の複数バリアントが要るため Effect.Tag を使う。
+// 注入 helper は `layer` とする (Effect.Tag 組み込みの `of` は Service 値を返す別物で衝突するため)。
+export class CompanyContext extends Effect.Tag("services/CompanyContext")<
+  CompanyContext,
+  CompanyContextShape
+>() {
+  static layer = (ctx: CompanyContextShape): Layer.Layer<CompanyContext> =>
+    Layer.succeed(this, ctx);
+}

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -1,8 +1,10 @@
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { PgDrizzleLive } from "../layers/lives/pg_drizzle_live";
+import { resolveCompanyIdOrRedirect } from "../lib/auth-guard";
 import { AccountValidationService } from "./account-validation-service";
 import { AuthClient } from "./auth-client-service";
 import { AuthService } from "./auth-service";
+import { CompanyContext } from "./company-context";
 import { CookieReader } from "./cookie-reader-service";
 import { CustomerService } from "./customer-service";
 import { DashboardService } from "./dashboard-service";
@@ -21,6 +23,7 @@ export {
   SessionError,
 } from "./auth-errors";
 export { AuthService } from "./auth-service";
+export { CompanyContext, type CompanyContextShape } from "./company-context";
 // CookieReader / CookieReadError は AuthService の内部依存として非公開
 // (Layer 配線でのみ使用、外部は AuthService の API のみを利用する)。
 export { CustomerServiceError } from "./customer-errors";
@@ -70,12 +73,41 @@ export const Live = Layer.mergeAll(
 );
 
 // Next.js の Server Actions から Effect を実行するため、
-// ManagedRuntime でリソース管理（DB 接続プール等）を自動化
+// ManagedRuntime でリソース管理（DB 接続プール等）を自動化。
+// runtime も返すことで scoped/非 scoped が同一 ManagedRuntime を共有する
+// (runScopedService が runtime を再構築して層分離を崩すのを防ぐ。docs/adr/0002 D3)。
 export const makeNextRuntime = <R, E>(layer: Layer.Layer<R, E, never>) => {
   const runtime = ManagedRuntime.make(layer);
-  const run = <A, E>(body: () => Effect.Effect<A, E, R>) =>
+  const run = <A, E2>(body: () => Effect.Effect<A, E2, R>) =>
     runtime.runPromise(Effect.either(body()));
-  return { run };
+  return { run, runtime };
 };
 
-export const { run: runService } = makeNextRuntime(Live);
+const { run: runService, runtime } = makeNextRuntime(Live);
+
+export { runService };
+
+// 事業所スコープ実行の閉じ。設計詳細: docs/adr/0002-company-data-scoping.md (D3)。
+// AllScopedServices は Live の ROut から機械導出する (手書き union 禁止 = Service 追加時の漏れ防止)。
+type AllScopedServices = Layer.Layer.Success<typeof Live>;
+
+// IDOR backstop 番兵 (閉じ1 を規律でなく型で固定): CompanyContext を Live に含めると
+// companyId 無し実行が型で通り backstop が破れる。含めた瞬間に下行がコンパイルエラーになる。
+type _NoCompanyContextInLive = [CompanyContext] extends [AllScopedServices]
+  ? "ERROR: CompanyContext must NOT be in Live"
+  : true;
+const _assertNoCompanyContextInLive: _NoCompanyContextInLive = true;
+
+// 事業所スコープ処理の唯一の実行口。companyId は引数で受けず境界の内側で session から導出する
+// (呼出側が間違った/欠けた companyId を渡す経路を API から消す)。
+// 未選択判定 + redirect は requireCompany と共有 (resolveCompanyIdOrRedirect、redirect SSOT)。
+export const runScopedService = async <A, E>(
+  body: () => Effect.Effect<A, E, AllScopedServices | CompanyContext>,
+) => {
+  const { companyId } = await resolveCompanyIdOrRedirect();
+  return runtime.runPromise(
+    Effect.either(
+      body().pipe(Effect.provideService(CompanyContext, { companyId })),
+    ),
+  );
+};

--- a/db/scoped.ts
+++ b/db/scoped.ts
@@ -1,0 +1,15 @@
+import { eq } from "drizzle-orm";
+import type { PgColumn } from "drizzle-orm/pg-core";
+
+// company_id を持つテーブルの scoping 条件の唯一の入口 (SSOT)。
+// 設計詳細: docs/adr/0002-company-data-scoping.md (D4)。
+//
+// 生の eq(table.companyId, ...) を Service に直書きせず必ずこの helper を通す。
+// これにより「scoped テーブルへの companyFilter 無しアクセス」を grep / review / lint で
+// 機械的に探せる (CompanyContext 方式は WHERE 付け忘れが型で防げない fail-open のため)。
+type ScopedTable = { companyId: PgColumn };
+
+export const companyFilter = <T extends ScopedTable>(
+  table: T,
+  companyId: string,
+) => eq(table.companyId, companyId);

--- a/docs/adr/0002-company-data-scoping.md
+++ b/docs/adr/0002-company-data-scoping.md
@@ -49,7 +49,8 @@ per-request の companyId / role を保持する Effect サービス。`effect-p
 // app/services/company-context.ts
 export interface CompanyContextShape {
   readonly companyId: string;
-  readonly role: string; // SDK の open Role 型 (proto enum re-export、exhaustive switch 回避: ADR-009 NC2)
+  // role は持たない (scoping のみ。認可は別層)。SDK 1.1.0 が実際に提供するのは companyId のみで
+  // currentCompanyName / currentCompanyRole は未提供 (PR-2 実装時に node_modules 型で観測)。
 }
 
 export class CompanyContext extends Effect.Tag("services/CompanyContext")<
@@ -90,7 +91,7 @@ create: (input) =>
 
 **create / update の外部参照 (`customerId`) は別途自社帰属を検証する (MECE CR1)**: `companyFilter` は invoices 行の read/update/delete を絞るが、INSERT/UPDATE 入力の外部 FK (`customerId`) の帰属は絞らない。`customers` FK はグローバルなので、他社 `customerId` を渡すと invoice 自体は自社 companyId で作られてしまう (cross-company 参照注入)。create/update は context の companyId で `customerId` の自社帰属を検証し、スコープ外なら `InvoiceNotFound` 相当で拒否する (型・`companyFilter` だけでは塞がらない = D3 の 3 重閉じの例外)。
 
-**`CompanyContext` は companyId のみ持ち role は入れない (freee 調査で裏付け)**: `CompanyContext` は scoping (= どの company のデータか) のみを担い、authorization (= 何ができるか) を持たない。freee も認可を session/membership とは別の専用層に置く — membership が持つのは「属性」(従業員 / アドバイザー) で、実際の権限判定は `AclKit` / `sekisyo` 権限セット (`PrivilegeControlService#xxx:read/:write` を controller `before_action` でチェック → 401/403) という別レイヤー (Sources「freee 参考調査」)。よって taimei も RBAC が必要になった時は `CompanyContext` を拡張せず、別の authorization 層 (例: `AuthorizationContext` + permission チェック) を新規に足す (Phase E+)。role は `requireCompany` が nav 表示用に session から返すので page 層では参照可能。
+**`CompanyContext` は companyId のみ持ち role は入れない (freee 調査で裏付け)**: `CompanyContext` は scoping (= どの company のデータか) のみを担い、authorization (= 何ができるか) を持たない。freee も認可を session/membership とは別の専用層に置く — membership が持つのは「属性」(従業員 / アドバイザー) で、実際の権限判定は `AclKit` / `sekisyo` 権限セット (`PrivilegeControlService#xxx:read/:write` を controller `before_action` でチェック → 401/403) という別レイヤー (Sources「freee 参考調査」)。よって taimei も RBAC が必要になった時は `CompanyContext` を拡張せず、別の authorization 層 (例: `AuthorizationContext` + permission チェック) を新規に足す (Phase E+)。なお SDK 1.1.0 は role を提供しない (companyId のみ) ため、role を要する nav 表示・認可は SDK 側が role を返すようになってから着手する (PR-2 実装時に観測)。
 
 ### D3. companyId の source は scoping 境界の内側で session から導出する (呼出側に渡させない)
 
@@ -121,10 +122,10 @@ export const runScopedService = async <A, E>(
   body: () => Effect.Effect<A, E, AllScopedServices | CompanyContext>,
 ) => {
   // 未選択判定 + redirect は requireCompany と共有 (redirect SSOT、D5)。Next 境界でしか取れない。
-  const { companyId, role } = await resolveCompanyIdOrRedirect();
+  const { companyId } = await resolveCompanyIdOrRedirect();
   return runtime.runPromise(
     Effect.either(
-      body().pipe(Effect.provideService(CompanyContext, { companyId, role })),
+      body().pipe(Effect.provideService(CompanyContext, { companyId })),
     ),
   );
 };
@@ -181,8 +182,8 @@ RLS は採らない (Alternatives Considered、本番課金前には過剰)。as
 ```ts
 // app/lib/auth-guard.ts — page UX 用の thin wrapper (redirect/companyId 導出は resolveCompanyIdOrRedirect に集約)
 export const requireCompany = async ({ returnTo }: { returnTo: string }) => {
-  const { companyId, role, session } = await resolveCompanyIdOrRedirect(returnTo);
-  return { ...session, companyId, role }; // nav 表示用に session も返す
+  const { companyId, session } = await resolveCompanyIdOrRedirect(returnTo);
+  return { ...session, companyId }; // nav 表示用に session も返す
 };
 ```
 
@@ -196,11 +197,11 @@ export const resolveCompanyIdOrRedirect = async (returnTo = "/dashboard") => {
   const session = await getSession(); // react.cache 済
   if (!session) redirect(`/auth?callbackUrl=${encodeURIComponent(returnTo)}`); // 未認証 → login
   if (!session.companyId) redirect(buildCompanySignupUrl(returnTo)); // 認証済・事業所未選択 → 登録
-  return { companyId: session.companyId, role: session.currentCompanyRole ?? "MEMBER", session };
+  return { companyId: session.companyId, session };
 };
 ```
 
-`requireCompany` は nav 表示用に `session` も返す薄い wrapper、`runScopedService` は `{ companyId, role }` のみ使う。
+`requireCompany` は nav 表示用に `session` も返す薄い wrapper、`runScopedService` は `{ companyId }` のみ使う。
 
 ### D6. cross-company アクセスは 404 (403 ではない)
 
@@ -281,7 +282,7 @@ Phase は手動 QA できる end-to-end 単位で分割 (ADR-009 流)。
 ### Phase 0: SDK upgrade (前提・極小 PR)
 
 - [ ] `package.json` の `@taimei-code/auth-client` を `^1.0.0` → `1.1.0` (**caret なし exact pin** — auth 側の `last_used_company_id` 意味変更を意図せず取り込まないため、DA #4) に上げ `bun install`。SDK contract test を CI 常時実行 (Phase 0 単発でなく)
-- [ ] `SessionData.companyId` / `currentCompanyName` / `currentCompanyRole` 型が consumer で見えることを確認
+- [ ] `SessionData.companyId` 型が consumer で見えることを確認 (1.1.0 は `currentCompanyName` / `currentCompanyRole` を提供せず companyId のみだった。PR-2 実装時に node_modules 型で観測)
 - [ ] `/api/auth/get-session` レスポンスに `companyId` が乗ることを Network tab / curl で確認
 - **AC**: SDK contract test 緑 + `bun tsc --noEmit` で companyId 型可視
 
@@ -357,7 +358,7 @@ dbEffect("InvoiceService は他社 invoice を返さない", ({ factory: f }) =>
     const svc = yield* InvoiceService;
     const res = yield* Effect.either(svc.findById(b.id)); // A context で B の id
     expect(Either.isLeft(res)).toBe(true); // InvoiceNotFound (404 相当)
-  }).pipe(Effect.provide(CompanyContext.of({ companyId: "cmp_aaa", role: "OWNER" }))),
+  }).pipe(Effect.provide(CompanyContext.layer({ companyId: "cmp_aaa" }))),
 );
 ```
 
@@ -457,7 +458,7 @@ PR ガイドライン (≤2 commits / ≤5 files) 超過は PR-2 (機構 + テ�
 
 ### 自動QA (Vitest、テストコード仕様)
 
-**前提 (全 isolation テストのブロッカー、PR-2)**: factory net-new (`customer`/`invoice`/`revenue`、companyId は **デフォルト無し=override 必須**) + `effect-test-helpers` は CompanyContext を**注入しない**設計 (各テストが `.pipe(Effect.provide(CompanyContext.of({ companyId, role })))`、provide 漏れがコンパイルエラー=backstop)。
+**前提 (全 isolation テストのブロッカー、PR-2)**: factory net-new (`customer`/`invoice`/`revenue`、companyId は **デフォルト無し=override 必須**) + `effect-test-helpers` は CompanyContext を**注入しない**設計 (各テストが `.pipe(Effect.provide(CompanyContext.layer({ companyId })))`、provide 漏れがコンパイルエラー=backstop)。
 
 自動カバー (dbEffect isolation / 型 / migration SQL):
 - **QA-E-04 ★** (閉じ1): `index.ts` の `_NoCompanyContextInLive` 番兵 + `bun tsc --noEmit` 緑 + `@ts-expect-error` で「scoped Service を runService に渡すと型エラー」を negative type test 固定。Live に CompanyContext を故意 merge して tsc が落ちることを 1 度確認 (Phase 1 手動チェック)


### PR DESCRIPTION
## やったこと

事業所データ scoping の機構を追加した。`runScopedService` (companyId を session から境界の内側で導出)、`companyFilter` (scoping 条件の SSOT)、`CompanyContext`、redirect + companyId 導出の SSOT (`resolveCompanyIdOrRedirect` / `requireCompany` / `buildCompanySignupUrl`)、テスト用 factory を用意した。

## なぜやるのか

後続 PR で各サービスの query を scope する際、companyId の取り回しと IDOR 防御を 1 箇所に集約し、付け忘れ・取り違え・パラメータ injection を型と境界で塞ぐため。

## 動作確認結果

`bun tsc --noEmit` 緑、`bun run test:db` 全 79 件緑。型番兵が機能することを、`Live` に `CompanyContext` を故意混入させると tsc が落ちることで確認した (混入除去で復帰)。

## 設計判断

IDOR backstop の中核は「company-scoped 処理を company context 無しで実行できない」という型保証 (閉じ1)。これを規律でなく型で固定するため、scoped 処理を実行できる集合 `AllScopedServices` を `Live` の出力型から機械導出し、`CompanyContext` がその集合に混入した瞬間にコンパイルエラーを出す番兵を置いた。手書きの union だとサービス追加時に scoping 漏れが起きるため機械導出にした。

`runScopedService` は companyId を引数で受けない。境界の内側で認証済 session から導出することで、呼出側が誤った companyId を渡す経路を API から消す。redirect は Next の control-flow throw で Effect 内では実行できないため、未選択判定と redirect は Effect の外 (Next 境界) に置き、companyId は「session から取り出し → 値として Effect へ注入」の一方向に倒した。

`CompanyContext` は companyId のみ持ち role を持たない。scoping (どの company か) と authorization (何ができるか) を分け、認可が要る時は別層を新設する方針。あわせて、インストール済の SDK 1.1.0 が実際に提供するのは `companyId` のみで会社名・ロールは未提供だったため、設計文書のコード例から role を除去して実装と整合させた。

テスト factory の company_id は固定 default ではなく sequence ユニークにした。固定 default だと分離テストで会社 id の指定を忘れた時に 2 社が同一になり誤って通過するため、忘れたら一致せず明確に失敗する方に倒した。

## やらなかったこと

各サービスの query 自体の scope (companyFilter の適用) は後続 PR で行う。この PR は機構と土台のみで、サービスの挙動は変えていない。

## レビューしてほしい観点

型番兵 (`_NoCompanyContextInLive`) のロジックと、`runScopedService` が companyId を session 由来に限定できているか。

## Revert 手順

このブランチの revert で機構ファイルが除去される。既存サービスの挙動を変えていないため安全に戻せる。
