### PR TITLE
feat(invoice): invoice/customer を company_id で scope し IDOR を塞ぐ (ADR-0002 PR-3)

### DIFF
--- a/app/lib/actions.ts
+++ b/app/lib/actions.ts
@@ -7,7 +7,12 @@ import { redirect } from "next/navigation";
 import { Email } from "@/app/domain/email";
 import { invoiceSchema } from "@/app/schema/invoice";
 import { emailLinkLoginSchema } from "@/app/schema/login";
-import { AuthService, InvoiceService, runService } from "@/app/services";
+import {
+  AuthService,
+  InvoiceService,
+  runScopedService,
+  runService,
+} from "@/app/services";
 import {
   AUTH_ERROR_MESSAGES,
   AUTH_SUCCESS_MESSAGES,
@@ -66,7 +71,7 @@ export async function createInvoice(_prevState: unknown, formData: FormData) {
   const { amount, status, customerId } = submission.value;
   const amountInCents = Math.round(amount * 100);
 
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* InvoiceService;
       return yield* service.create({
@@ -78,9 +83,16 @@ export async function createInvoice(_prevState: unknown, formData: FormData) {
   );
 
   if (Either.isLeft(result)) {
-    return submission.reply({
-      formErrors: [`請求書の作成に失敗しました: ${result.left._tag}`],
-    });
+    switch (result.left._tag) {
+      case "CustomerNotInScope":
+        return submission.reply({
+          fieldErrors: { customerId: ["指定した顧客が見つかりません"] },
+        });
+      default:
+        return submission.reply({
+          formErrors: ["請求書の作成に失敗しました"],
+        });
+    }
   }
 
   revalidatePath("/dashboard/invoices");
@@ -101,7 +113,7 @@ export async function updateInvoice(
   const { amount, status, customerId } = submission.value;
   const amountInCents = Math.round(amount * 100);
 
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* InvoiceService;
       return yield* service.update({
@@ -119,9 +131,13 @@ export async function updateInvoice(
         return submission.reply({
           formErrors: ["請求書が見つかりません"],
         });
+      case "CustomerNotInScope":
+        return submission.reply({
+          fieldErrors: { customerId: ["指定した顧客が見つかりません"] },
+        });
       default:
         return submission.reply({
-          formErrors: [`請求書の更新に失敗しました: ${result.left._tag}`],
+          formErrors: ["請求書の更新に失敗しました"],
         });
     }
   }
@@ -131,7 +147,7 @@ export async function updateInvoice(
 }
 
 export async function deleteInvoice(id: string, _prevState: unknown) {
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* InvoiceService;
       return yield* service.delete(id);
@@ -146,7 +162,7 @@ export async function deleteInvoice(id: string, _prevState: unknown) {
       default:
         await setFlash({
           type: "error",
-          message: `Failed to delete invoice: ${result.left._tag}`,
+          message: "Failed to delete invoice.",
         });
     }
     revalidatePath("/dashboard/invoices");

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -6,6 +6,7 @@ import {
   InvoiceService,
   type LatestInvoice,
   type Revenue,
+  runScopedService,
   runService,
 } from "@/app/services";
 import { getSession } from "./auth-guard";
@@ -123,7 +124,7 @@ export async function fetchFilteredInvoices(
   query: string,
   currentPage: number,
 ): Promise<FilteredInvoice[]> {
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* InvoiceService;
       return yield* service.fetchFiltered(query, currentPage);
@@ -147,7 +148,7 @@ export async function fetchFilteredInvoices(
 }
 
 export async function fetchInvoicesPages(query: string): Promise<number> {
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* InvoiceService;
       return yield* service.fetchPages(query);
@@ -165,7 +166,7 @@ export async function fetchInvoicesPages(query: string): Promise<number> {
 export async function fetchInvoiceById(
   id: string,
 ): Promise<InvoiceSelectionById | null> {
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* InvoiceService;
       return yield* service.findById(id);
@@ -189,7 +190,7 @@ export async function fetchInvoiceById(
 }
 
 export async function fetchCustomers(): Promise<CustomerField[]> {
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* CustomerService;
       return yield* service.findAll();
@@ -207,7 +208,7 @@ export async function fetchCustomers(): Promise<CustomerField[]> {
 export async function fetchFilteredCustomers(
   query: string,
 ): Promise<FilteredCustomer[]> {
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* CustomerService;
       return yield* service.fetchFiltered(query);

--- a/app/services/__tests__/customer-service.test.ts
+++ b/app/services/__tests__/customer-service.test.ts
@@ -1,29 +1,83 @@
 import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { describe } from "vitest";
+import { CompanyContext } from "../company-context";
 import { CustomerService } from "../customer-service";
 import { dbEffect } from "./db/effect-test-helpers";
 
+const A = "cmp_aaa";
+const B = "cmp_bbb";
+
 describe("CustomerService", () => {
-  describe("findAll", () => {
+  describe("findAll / fetchFiltered (空)", () => {
     dbEffect("正常系: 顧客がいない場合は空配列を返す", () =>
       Effect.gen(function* () {
         const service = yield* CustomerService;
         const customers = yield* service.findAll();
-
         expect(customers).toHaveLength(0);
-      }),
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
     );
-  });
 
-  describe("fetchFiltered", () => {
-    dbEffect("正常系: 顧客がいない場合は空配列を返す", () =>
+    dbEffect("正常系: 該当顧客がいない場合は空配列を返す", () =>
       Effect.gen(function* () {
         const service = yield* CustomerService;
         const customers = yield* service.fetchFiltered("alice");
-
         expect(customers).toHaveLength(0);
-      }),
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+  });
+
+  describe("scoping (自社 customer のみ)", () => {
+    dbEffect(
+      "findAll は自社 customer のみ返す (dropdown に他社が出ない)",
+      ({ factory: f }) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            f.customer.create({ companyId: A, name: "Alice" }),
+          );
+          yield* Effect.promise(() =>
+            f.customer.create({ companyId: B, name: "Bob" }),
+          );
+          const service = yield* CustomerService;
+          const list = yield* service.findAll();
+          expect(list).toHaveLength(1);
+          expect(list[0]?.name).toBe("Alice");
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+  });
+
+  describe("集計 leak 防止 (他社金額の混入なし)", () => {
+    dbEffect(
+      "fetchFiltered の totalPaid に他社 invoice 金額が混入しない",
+      ({ factory: f }) =>
+        Effect.gen(function* () {
+          const aCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: A, name: "Acme" }),
+          );
+          // 自社 (A) の paid invoice (500)。
+          yield* Effect.promise(() =>
+            f.invoice.create({
+              companyId: A,
+              customerId: aCustomer.id,
+              status: "paid",
+              amount: 500,
+            }),
+          );
+          // 他社 (B) が A の customer を参照する stray invoice (factory で直接作成し service 検証を迂回)。
+          // leftJoin の ON に companyFilter(invoices) が無いと totalPaid に 9999 が混入する。
+          yield* Effect.promise(() =>
+            f.invoice.create({
+              companyId: B,
+              customerId: aCustomer.id,
+              status: "paid",
+              amount: 9999,
+            }),
+          );
+          const service = yield* CustomerService;
+          const list = yield* service.fetchFiltered("Acme");
+          expect(list).toHaveLength(1);
+          expect(list[0]?.totalPaid).toBe(500);
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
     );
   });
 });

--- a/app/services/__tests__/invoice-service.test.ts
+++ b/app/services/__tests__/invoice-service.test.ts
@@ -1,29 +1,174 @@
 import { expect } from "@effect/vitest";
-import { Effect } from "effect";
+import { eq } from "drizzle-orm";
+import { Effect, Either } from "effect";
 import { describe } from "vitest";
+import { invoices } from "@/db/drizzle/schema";
+import { companyFilter } from "@/db/scoped";
+import { CompanyContext } from "../company-context";
 import { InvoiceService } from "../invoice-service";
 import { dbEffect } from "./db/effect-test-helpers";
 
+// scoped Service は CompanyContext を要求するため、各テストは CompanyContext.layer を provide する。
+// provide 漏れは ServiceLayer に CompanyContext が残りコンパイルエラー (閉じ1 backstop)。
+const A = "cmp_aaa";
+const B = "cmp_bbb";
+
 describe("InvoiceService", () => {
-  describe("fetchPages", () => {
+  describe("fetchPages / fetchFiltered (空)", () => {
     dbEffect("正常系: データがない場合は0ページを返す", () =>
       Effect.gen(function* () {
         const service = yield* InvoiceService;
         const pages = yield* service.fetchPages("");
-
         expect(pages).toBe(0);
-      }),
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
     );
-  });
 
-  describe("fetchFiltered", () => {
     dbEffect("正常系: データがない場合は空配列を返す", () =>
       Effect.gen(function* () {
         const service = yield* InvoiceService;
-        const invoices = yield* service.fetchFiltered("", 1);
+        const list = yield* service.fetchFiltered("", 1);
+        expect(list).toHaveLength(0);
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+  });
 
-        expect(invoices).toHaveLength(0);
-      }),
+  describe("scoping (cross-company 不可視)", () => {
+    dbEffect(
+      "findById: A context で B invoice は InvoiceNotFound (404)",
+      ({ factory: f }) =>
+        Effect.gen(function* () {
+          const b = yield* Effect.promise(() =>
+            f.invoice.create({ companyId: B }),
+          );
+          const service = yield* InvoiceService;
+          const res = yield* Effect.either(service.findById(b.id));
+          expect(Either.isLeft(res)).toBe(true);
+          if (Either.isLeft(res)) expect(res.left._tag).toBe("InvoiceNotFound");
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect(
+      "fetchFiltered: A context は自社 invoice のみ返す",
+      ({ factory: f }) =>
+        Effect.gen(function* () {
+          const aCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: A, name: "Alice" }),
+          );
+          yield* Effect.promise(() =>
+            f.invoice.create({ companyId: A, customerId: aCustomer.id }),
+          );
+          const bCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: B, name: "Bob" }),
+          );
+          yield* Effect.promise(() =>
+            f.invoice.create({ companyId: B, customerId: bCustomer.id }),
+          );
+          const service = yield* InvoiceService;
+          const list = yield* service.fetchFiltered("", 1);
+          expect(list).toHaveLength(1);
+          expect(list[0]?.name).toBe("Alice");
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+  });
+
+  describe("mutation IDOR", () => {
+    dbEffect(
+      "update: A context で B invoice id + 自社 customerId → InvoiceNotFound かつ B 行不変 (invoice scope 防御)",
+      ({ factory: f, tx }) =>
+        Effect.gen(function* () {
+          // 自社 customerId を渡すことで customer 検証は通過させ、invoice 側の
+          // companyFilter (WHERE) が他社 invoice を 0 行更新で防ぐことを固定する。
+          const aCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: A }),
+          );
+          const b = yield* Effect.promise(() =>
+            f.invoice.create({ companyId: B, amount: 500 }),
+          );
+          const service = yield* InvoiceService;
+          const res = yield* Effect.either(
+            service.update({
+              id: b.id,
+              customerId: aCustomer.id,
+              amount: 99999,
+              status: "paid",
+            }),
+          );
+          expect(Either.isLeft(res)).toBe(true);
+          if (Either.isLeft(res)) expect(res.left._tag).toBe("InvoiceNotFound");
+          // B 行が変更されていない (rows affected=0)。
+          const rows = yield* Effect.promise(() =>
+            tx
+              .select({ amount: invoices.amount })
+              .from(invoices)
+              .where(eq(invoices.id, b.id)),
+          );
+          expect(rows[0]?.amount).toBe(500);
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect(
+      "delete: A context で B invoice → 404 かつ B 行不変",
+      ({ factory: f, tx }) =>
+        Effect.gen(function* () {
+          const b = yield* Effect.promise(() =>
+            f.invoice.create({ companyId: B }),
+          );
+          const service = yield* InvoiceService;
+          const res = yield* Effect.either(service.delete(b.id));
+          expect(Either.isLeft(res)).toBe(true);
+          const rows = yield* Effect.promise(() =>
+            tx
+              .select({ id: invoices.id })
+              .from(invoices)
+              .where(eq(invoices.id, b.id)),
+          );
+          expect(rows).toHaveLength(1);
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect(
+      "create: A context で B customerId → 拒否 かつ A 行が作られない",
+      ({ factory: f, tx }) =>
+        Effect.gen(function* () {
+          const bCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: B }),
+          );
+          const service = yield* InvoiceService;
+          const res = yield* Effect.either(
+            service.create({
+              customerId: bCustomer.id,
+              amount: 100,
+              status: "pending",
+            }),
+          );
+          expect(Either.isLeft(res)).toBe(true);
+          if (Either.isLeft(res))
+            expect(res.left._tag).toBe("CustomerNotInScope");
+          const rows = yield* Effect.promise(() =>
+            tx
+              .select({ id: invoices.id })
+              .from(invoices)
+              .where(companyFilter(invoices, A)),
+          );
+          expect(rows).toHaveLength(0);
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect(
+      "create: A context で A customerId → companyId=A が自動付与される",
+      ({ factory: f }) =>
+        Effect.gen(function* () {
+          const aCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: A }),
+          );
+          const service = yield* InvoiceService;
+          const created = yield* service.create({
+            customerId: aCustomer.id,
+            amount: 100,
+            status: "pending",
+          });
+          expect(created.companyId).toBe(A);
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
     );
   });
 });

--- a/app/services/customer-service.ts
+++ b/app/services/customer-service.ts
@@ -1,9 +1,12 @@
 import * as PgDrizzle from "@effect/sql-drizzle/Pg";
-import { eq, ilike, or, sql } from "drizzle-orm";
+import { and, eq, ilike, or, sql } from "drizzle-orm";
 import { Effect } from "effect";
 import { customers, invoices } from "@/db/drizzle/schema";
+import { companyFilter } from "@/db/scoped";
+import { CompanyContext } from "./company-context";
 import { CustomerServiceError } from "./customer-errors";
 
+// 全 query は CompanyContext の companyId で scope する。設計詳細: docs/adr/0002-company-data-scoping.md。
 export class CustomerService extends Effect.Service<CustomerService>()(
   "services/CustomerService",
   {
@@ -11,75 +14,95 @@ export class CustomerService extends Effect.Service<CustomerService>()(
       const pgdrizzle = yield* PgDrizzle.PgDrizzle;
 
       return {
+        // invoice 作成 dropdown のソース。無 scope だと他社 customer が候補に出るため必ず scope する。
         findAll: () =>
-          Effect.tryPromise({
-            try: () =>
-              pgdrizzle
-                .select({
-                  id: customers.id,
-                  name: customers.name,
-                })
-                .from(customers)
-                .orderBy(customers.name),
-            catch: (e) =>
-              new CustomerServiceError({
-                message: `findAll failed: ${e}`,
-              }),
+          Effect.gen(function* () {
+            const { companyId } = yield* CompanyContext;
+            return yield* Effect.tryPromise({
+              try: () =>
+                pgdrizzle
+                  .select({
+                    id: customers.id,
+                    name: customers.name,
+                  })
+                  .from(customers)
+                  .where(companyFilter(customers, companyId))
+                  .orderBy(customers.name),
+              catch: (e) =>
+                new CustomerServiceError({
+                  message: `findAll failed: ${e}`,
+                }),
+            });
           }),
 
         fetchFiltered: (query: string) =>
-          Effect.tryPromise({
-            try: async () => {
-              const searchPattern = `%${query}%`;
+          Effect.gen(function* () {
+            const { companyId } = yield* CompanyContext;
+            return yield* Effect.tryPromise({
+              try: async () => {
+                const searchPattern = `%${query}%`;
 
-              const result = await pgdrizzle
-                .select({
-                  id: customers.id,
-                  name: customers.name,
-                  email: customers.email,
-                  imageUrl: customers.imageUrl,
-                  totalInvoices: sql<number>`count(${invoices.id})`.as(
-                    "total_invoices",
-                  ),
-                  totalPending:
-                    sql<number>`sum(case when ${invoices.status} = 'pending' then ${invoices.amount} else 0 end)`.as(
-                      "total_pending",
+                const result = await pgdrizzle
+                  .select({
+                    id: customers.id,
+                    name: customers.name,
+                    email: customers.email,
+                    imageUrl: customers.imageUrl,
+                    totalInvoices: sql<number>`count(${invoices.id})`.as(
+                      "total_invoices",
                     ),
-                  totalPaid:
-                    sql<number>`sum(case when ${invoices.status} = 'paid' then ${invoices.amount} else 0 end)`.as(
-                      "total_paid",
+                    totalPending:
+                      sql<number>`sum(case when ${invoices.status} = 'pending' then ${invoices.amount} else 0 end)`.as(
+                        "total_pending",
+                      ),
+                    totalPaid:
+                      sql<number>`sum(case when ${invoices.status} = 'paid' then ${invoices.amount} else 0 end)`.as(
+                        "total_paid",
+                      ),
+                  })
+                  .from(customers)
+                  // leftJoin の ON 句に invoices 側 companyFilter を AND する。
+                  // customers を WHERE で絞っても join 先 invoices を絞らないと集計金額に
+                  // 他社 invoice が混入する。
+                  .leftJoin(
+                    invoices,
+                    and(
+                      eq(customers.id, invoices.customerId),
+                      companyFilter(invoices, companyId),
                     ),
-                })
-                .from(customers)
-                .leftJoin(invoices, eq(customers.id, invoices.customerId))
-                .where(
-                  or(
-                    ilike(customers.name, searchPattern),
-                    ilike(customers.email, searchPattern),
-                  ),
-                )
-                .groupBy(
-                  customers.id,
-                  customers.name,
-                  customers.email,
-                  customers.imageUrl,
-                )
-                .orderBy(customers.name);
+                  )
+                  .where(
+                    and(
+                      companyFilter(customers, companyId),
+                      or(
+                        ilike(customers.name, searchPattern),
+                        ilike(customers.email, searchPattern),
+                      ),
+                    ),
+                  )
+                  .groupBy(
+                    customers.id,
+                    customers.name,
+                    customers.email,
+                    customers.imageUrl,
+                  )
+                  .orderBy(customers.name);
 
-              return result.map((row) => ({
-                id: row.id,
-                name: row.name,
-                email: row.email,
-                imageUrl: row.imageUrl,
-                totalInvoices: Number(row.totalInvoices),
-                totalPending: Number(row.totalPending) || 0,
-                totalPaid: Number(row.totalPaid) || 0,
-              }));
-            },
-            catch: (e) =>
-              new CustomerServiceError({
-                message: `fetchFiltered failed: ${e}`,
-              }),
+                return result.map((row) => ({
+                  id: row.id,
+                  name: row.name,
+                  email: row.email,
+                  imageUrl: row.imageUrl,
+                  totalInvoices: Number(row.totalInvoices),
+                  totalPending: Number(row.totalPending) || 0,
+                  totalPaid: Number(row.totalPaid) || 0,
+                }));
+              },
+              catch: (e) =>
+                new CustomerServiceError({
+                  message: `fetchFiltered failed: ${e}`,
+                }),
+            });
           }),
       } as const;
     }),

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -37,7 +37,11 @@ export {
 } from "./dashboard-service";
 // 外部から直接 import できるようにエクスポート（パス簡略化のため）
 export { IdGenerator } from "./id-generator-service";
-export { InvoiceNotFound, InvoiceServiceError } from "./invoice-errors";
+export {
+  CustomerNotInScope,
+  InvoiceNotFound,
+  InvoiceServiceError,
+} from "./invoice-errors";
 export {
   type CreateInvoiceInput,
   InvoiceService,

--- a/app/services/invoice-errors.ts
+++ b/app/services/invoice-errors.ts
@@ -9,3 +9,9 @@ export class InvoiceServiceError extends Data.TaggedError(
 )<{
   message: string;
 }> {}
+
+// invoice の作成/更新で指定された customerId が自社スコープ外だった場合に投げる。
+// InvoiceNotFound (invoice 不在) と区別し、呼出側が顧客向け文言を出せるようにする。
+export class CustomerNotInScope extends Data.TaggedError("CustomerNotInScope")<{
+  customerId: string;
+}> {}

--- a/app/services/invoice-service.ts
+++ b/app/services/invoice-service.ts
@@ -1,8 +1,14 @@
 import * as PgDrizzle from "@effect/sql-drizzle/Pg";
-import { count, desc, eq, ilike, or, sql } from "drizzle-orm";
+import { and, count, desc, eq, ilike, or, sql } from "drizzle-orm";
 import { Effect } from "effect";
 import { customers, invoices } from "@/db/drizzle/schema";
-import { InvoiceNotFound, InvoiceServiceError } from "./invoice-errors";
+import { companyFilter } from "@/db/scoped";
+import { CompanyContext } from "./company-context";
+import {
+  CustomerNotInScope,
+  InvoiceNotFound,
+  InvoiceServiceError,
+} from "./invoice-errors";
 
 export type CreateInvoiceInput = {
   customerId: string;
@@ -17,33 +23,77 @@ export type UpdateInvoiceInput = {
   status: string;
 };
 
+// 全 query は CompanyContext の companyId で scope する。設計詳細: docs/adr/0002-company-data-scoping.md。
 export class InvoiceService extends Effect.Service<InvoiceService>()(
   "services/InvoiceService",
   {
     effect: Effect.gen(function* () {
       const pgdrizzle = yield* PgDrizzle.PgDrizzle;
 
-      return {
-        create: (input: CreateInvoiceInput) =>
-          Effect.tryPromise({
+      // customerId が自社 (companyId) に帰属するか検証する。
+      // customers FK はグローバルなので、companyFilter で invoices を絞っても、他社 customerId を
+      // 渡すと invoice が自社 companyId で作られる cross-company 参照注入になる。型・companyFilter
+      // では塞がらないため mutation 入力 FK は明示検証する。設計詳細: docs/adr/0002-company-data-scoping.md。
+      const assertCustomerInCompany = (customerId: string, companyId: string) =>
+        Effect.gen(function* () {
+          const owned = yield* Effect.tryPromise({
             try: () =>
               pgdrizzle
-                .insert(invoices)
-                .values({
-                  customerId: input.customerId,
-                  amount: input.amount,
-                  status: input.status,
-                })
-                .returning()
-                .then((res) => res[0]),
+                .select({ id: customers.id })
+                .from(customers)
+                .where(
+                  and(
+                    eq(customers.id, customerId),
+                    companyFilter(customers, companyId),
+                  ),
+                )
+                .then((r) => r.at(0)),
             catch: (e) =>
               new InvoiceServiceError({
-                message: `create failed: ${e}`,
+                message: `customer ownership check failed: ${e}`,
               }),
+          });
+          if (!owned) {
+            // fail-open の本番検知系。正常 not-found と区別できる構造化ログを残す。
+            console.error("cross-company write attempt", {
+              kind: "invoice.customerId",
+              attemptedCompanyId: companyId,
+              targetCustomerId: customerId,
+            });
+            return yield* new CustomerNotInScope({ customerId });
+          }
+        });
+
+      return {
+        create: (input: CreateInvoiceInput) =>
+          Effect.gen(function* () {
+            const { companyId } = yield* CompanyContext;
+            // companyId は引数ではなく context から付与する (取り違え防止)。
+            yield* assertCustomerInCompany(input.customerId, companyId);
+            return yield* Effect.tryPromise({
+              try: () =>
+                pgdrizzle
+                  .insert(invoices)
+                  .values({
+                    customerId: input.customerId,
+                    amount: input.amount,
+                    status: input.status,
+                    companyId,
+                  })
+                  .returning()
+                  .then((res) => res[0]),
+              catch: (e) =>
+                new InvoiceServiceError({
+                  message: `create failed: ${e}`,
+                }),
+            });
           }),
 
         update: (input: UpdateInvoiceInput) =>
           Effect.gen(function* () {
+            const { companyId } = yield* CompanyContext;
+            yield* assertCustomerInCompany(input.customerId, companyId);
+            // 他社 id は companyFilter で除外され 0 行更新 → not-found (他社行は不変)。
             const result = yield* Effect.tryPromise({
               try: () =>
                 pgdrizzle
@@ -53,7 +103,12 @@ export class InvoiceService extends Effect.Service<InvoiceService>()(
                     amount: input.amount,
                     status: input.status,
                   })
-                  .where(eq(invoices.id, input.id))
+                  .where(
+                    and(
+                      eq(invoices.id, input.id),
+                      companyFilter(invoices, companyId),
+                    ),
+                  )
                   .returning()
                   .then((res) => res.at(0)),
               catch: (e) =>
@@ -69,36 +124,33 @@ export class InvoiceService extends Effect.Service<InvoiceService>()(
 
         delete: (id: string) =>
           Effect.gen(function* () {
-            const existing = yield* Effect.tryPromise({
-              try: () =>
-                pgdrizzle
-                  .select({ id: invoices.id })
-                  .from(invoices)
-                  .where(eq(invoices.id, id))
-                  .then((res) => res.at(0)),
-              catch: (e) =>
-                new InvoiceServiceError({
-                  message: `delete findById failed: ${e}`,
-                }),
-            });
-            if (!existing) {
-              return yield* new InvoiceNotFound({ id });
-            }
-            yield* Effect.tryPromise({
+            const { companyId } = yield* CompanyContext;
+            // 他社 id は WHERE で 0 行 hit → returning 空 → 404 (rows affected=0、他社行を消さない)。
+            const deleted = yield* Effect.tryPromise({
               try: () =>
                 pgdrizzle
                   .delete(invoices)
-                  .where(eq(invoices.id, id))
-                  .returning(),
+                  .where(
+                    and(
+                      eq(invoices.id, id),
+                      companyFilter(invoices, companyId),
+                    ),
+                  )
+                  .returning({ id: invoices.id }),
               catch: (e) =>
                 new InvoiceServiceError({
                   message: `delete failed: ${e}`,
                 }),
             });
+            if (deleted.length === 0) {
+              return yield* new InvoiceNotFound({ id });
+            }
           }),
 
         findById: (id: string) =>
           Effect.gen(function* () {
+            const { companyId } = yield* CompanyContext;
+            // 他社 id は WHERE で除外 → 空 → InvoiceNotFound (404 = 存在自体を隠蔽)。
             const result = yield* Effect.tryPromise({
               try: () =>
                 pgdrizzle
@@ -109,7 +161,12 @@ export class InvoiceService extends Effect.Service<InvoiceService>()(
                     status: invoices.status,
                   })
                   .from(invoices)
-                  .where(eq(invoices.id, id))
+                  .where(
+                    and(
+                      eq(invoices.id, id),
+                      companyFilter(invoices, companyId),
+                    ),
+                  )
                   .then((res) => res.at(0)),
               catch: (e) =>
                 new InvoiceServiceError({
@@ -123,67 +180,79 @@ export class InvoiceService extends Effect.Service<InvoiceService>()(
           }),
 
         fetchFiltered: (query: string, currentPage: number, itemsPerPage = 6) =>
-          Effect.tryPromise({
-            try: () => {
-              const offset = (currentPage - 1) * itemsPerPage;
-              const searchPattern = `%${query}%`;
+          Effect.gen(function* () {
+            const { companyId } = yield* CompanyContext;
+            return yield* Effect.tryPromise({
+              try: () => {
+                const offset = (currentPage - 1) * itemsPerPage;
+                const searchPattern = `%${query}%`;
 
-              return pgdrizzle
-                .select({
-                  id: invoices.id,
-                  amount: invoices.amount,
-                  date: invoices.date,
-                  status: invoices.status,
-                  name: customers.name,
-                  email: customers.email,
-                  imageUrl: customers.imageUrl,
-                })
-                .from(invoices)
-                .innerJoin(customers, eq(invoices.customerId, customers.id))
-                .where(
-                  or(
-                    ilike(customers.name, searchPattern),
-                    ilike(customers.email, searchPattern),
-                    ilike(invoices.status, searchPattern),
-                    sql`${invoices.amount}::text ILIKE ${searchPattern}`,
-                    sql`${invoices.date}::text ILIKE ${searchPattern}`,
-                  ),
-                )
-                .orderBy(desc(invoices.date))
-                .limit(itemsPerPage)
-                .offset(offset);
-            },
-            catch: (e) =>
-              new InvoiceServiceError({
-                message: `fetchFiltered failed: ${e}`,
-              }),
+                return pgdrizzle
+                  .select({
+                    id: invoices.id,
+                    amount: invoices.amount,
+                    date: invoices.date,
+                    status: invoices.status,
+                    name: customers.name,
+                    email: customers.email,
+                    imageUrl: customers.imageUrl,
+                  })
+                  .from(invoices)
+                  .innerJoin(customers, eq(invoices.customerId, customers.id))
+                  .where(
+                    and(
+                      companyFilter(invoices, companyId),
+                      or(
+                        ilike(customers.name, searchPattern),
+                        ilike(customers.email, searchPattern),
+                        ilike(invoices.status, searchPattern),
+                        sql`${invoices.amount}::text ILIKE ${searchPattern}`,
+                        sql`${invoices.date}::text ILIKE ${searchPattern}`,
+                      ),
+                    ),
+                  )
+                  .orderBy(desc(invoices.date))
+                  .limit(itemsPerPage)
+                  .offset(offset);
+              },
+              catch: (e) =>
+                new InvoiceServiceError({
+                  message: `fetchFiltered failed: ${e}`,
+                }),
+            });
           }),
 
         fetchPages: (query: string, itemsPerPage = 6) =>
-          Effect.tryPromise({
-            try: async () => {
-              const searchPattern = `%${query}%`;
+          Effect.gen(function* () {
+            const { companyId } = yield* CompanyContext;
+            return yield* Effect.tryPromise({
+              try: async () => {
+                const searchPattern = `%${query}%`;
 
-              const result = await pgdrizzle
-                .select({ count: count() })
-                .from(invoices)
-                .innerJoin(customers, eq(invoices.customerId, customers.id))
-                .where(
-                  or(
-                    ilike(customers.name, searchPattern),
-                    ilike(customers.email, searchPattern),
-                    ilike(invoices.status, searchPattern),
-                    sql`${invoices.amount}::text ILIKE ${searchPattern}`,
-                    sql`${invoices.date}::text ILIKE ${searchPattern}`,
-                  ),
-                );
+                const result = await pgdrizzle
+                  .select({ count: count() })
+                  .from(invoices)
+                  .innerJoin(customers, eq(invoices.customerId, customers.id))
+                  .where(
+                    and(
+                      companyFilter(invoices, companyId),
+                      or(
+                        ilike(customers.name, searchPattern),
+                        ilike(customers.email, searchPattern),
+                        ilike(invoices.status, searchPattern),
+                        sql`${invoices.amount}::text ILIKE ${searchPattern}`,
+                        sql`${invoices.date}::text ILIKE ${searchPattern}`,
+                      ),
+                    ),
+                  );
 
-              return Math.ceil(Number(result[0].count) / itemsPerPage);
-            },
-            catch: (e) =>
-              new InvoiceServiceError({
-                message: `fetchPages failed: ${e}`,
-              }),
+                return Math.ceil(Number(result[0].count) / itemsPerPage);
+              },
+              catch: (e) =>
+                new InvoiceServiceError({
+                  message: `fetchPages failed: ${e}`,
+                }),
+            });
           }),
       } as const;
     }),


### PR DESCRIPTION
## やったこと

`InvoiceService` / `CustomerService` の全 query を session 由来の companyId で scope し、呼出側を `runScopedService` 経由にした。他社リソースは読み取り・更新・削除いずれも 404 とし、作成時の顧客指定も自社帰属を検証する。cross-company の isolation テストを追加した。

## なぜやるのか

事業所ごとにデータを分離し、他社の請求書・顧客の閲覧/改変 (IDOR) を構造的に塞ぐため。

## 動作確認結果

`bun run test:db` 全 87 件緑 (isolation テスト含む)。dev 環境で 2 社のデータを用意し、自社のみ一覧表示・他社請求書 id 直打ちで 404・作成 dropdown が自社顧客のみ・事業所未選択で登録ページへ redirect を確認した。

## 設計判断

他社リソースは 403 ではなく 404 を返す。存在自体を漏らさないため、scoped query が他社行を WHERE で除外して空になり not-found に倒れる。読み取りだけでなく更新・削除も同じ WHERE で 0 行に倒し、他社行を変更しない。

作成・更新で渡される customerId は別途 SELECT で自社帰属を検証する。顧客マスタの外部キーはグローバルで、請求書側を scope しても他社 customerId を渡せば自社 companyId の請求書として作られてしまうため。型や WHERE では塞げない入力なので明示検証し、スコープ外は専用エラーで拒否して画面には内部エラー名を出さず顧客向け文言を返す。

顧客一覧の集計 (合計金額) は、顧客と請求書の結合の ON 句に請求書側の company 条件も付ける。顧客を絞っても結合先の請求書を絞らないと、他社の請求書金額が合計に乗るため。

cross-company の書き込み試行 (他社 customerId 指定など) は構造化ログに記録する。付け忘れ型の漏れ (fail-open) が本番で起きても後から検知・集計できるようにするため。

## やらなかったこと

ダッシュボード (売上チャート / カード / 最新請求書) の scope は後続 PR で行う。タグの scope は Phase 2。

## レビューしてほしい観点

他社リソースの 404 化と、作成/更新時の customerId 自社帰属検証が漏れなく入っているか。

## Revert 手順

このブランチの revert で query が無 scope に戻る。schema 変更を含まないため DB 影響なし。
