### PR TITLE
feat(dashboard): overview 集計を company_id で scope する (ADR-0002 PR-4)

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,4 +1,4 @@
-import { requireSession } from "@/app/lib/auth-guard";
+import { requireCompany } from "@/app/lib/auth-guard";
 import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
@@ -9,8 +9,11 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
+  // requireCompany は page レベル UX ガード: 事業所未選択なら data fetch 前に redirect して
+  // 描画チラつきを防ぐ。security backstop は各 runScopedService 自身。
+  // 設計詳細: docs/adr/0002-company-data-scoping.md
   const [, currentUser] = await Promise.all([
-    requireSession({ returnTo: "/dashboard" }),
+    requireCompany({ returnTo: "/dashboard" }),
     fetchCurrentUser(),
   ]);
 

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -7,7 +7,6 @@ import {
   type LatestInvoice,
   type Revenue,
   runScopedService,
-  runService,
 } from "@/app/services";
 import { getSession } from "./auth-guard";
 
@@ -34,7 +33,7 @@ export async function fetchCurrentUser(): Promise<CurrentUser> {
 }
 
 export async function fetchRevenue(): Promise<Revenue[]> {
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* DashboardService;
       return yield* service.fetchRevenue();
@@ -50,7 +49,7 @@ export async function fetchRevenue(): Promise<Revenue[]> {
 }
 
 export async function fetchLatestInvoices(): Promise<LatestInvoice[]> {
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* DashboardService;
       return yield* service.fetchLatestInvoices();
@@ -66,7 +65,7 @@ export async function fetchLatestInvoices(): Promise<LatestInvoice[]> {
 }
 
 export async function fetchCardData(): Promise<CardData> {
-  const result = await runService(() =>
+  const result = await runScopedService(() =>
     Effect.gen(function* () {
       const service = yield* DashboardService;
       return yield* service.fetchCardData();

--- a/app/services/__tests__/dashboard-service.test.ts
+++ b/app/services/__tests__/dashboard-service.test.ts
@@ -1,8 +1,12 @@
 import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { describe } from "vitest";
+import { CompanyContext } from "../company-context";
 import { DashboardService } from "../dashboard-service";
 import { dbEffect } from "./db/effect-test-helpers";
+
+const A = "cmp_aaa";
+const B = "cmp_bbb";
 
 describe("DashboardService", () => {
   describe("fetchCardData", () => {
@@ -15,7 +19,43 @@ describe("DashboardService", () => {
         expect(cardData.numberOfInvoices).toBe(0);
         expect(cardData.totalPaidInvoices).toBe("$0.00");
         expect(cardData.totalPendingInvoices).toBe("$0.00");
-      }),
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect(
+      "集計 (件数・金額) が自社のみで他社が混入しない",
+      ({ factory: f }) =>
+        Effect.gen(function* () {
+          const aCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: A }),
+          );
+          yield* Effect.promise(() =>
+            f.invoice.create({
+              companyId: A,
+              customerId: aCustomer.id,
+              status: "paid",
+              amount: 500,
+            }),
+          );
+          const bCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: B }),
+          );
+          yield* Effect.promise(() =>
+            f.invoice.create({
+              companyId: B,
+              customerId: bCustomer.id,
+              status: "paid",
+              amount: 9999,
+            }),
+          );
+          const service = yield* DashboardService;
+          const cardData = yield* service.fetchCardData();
+
+          expect(cardData.numberOfCustomers).toBe(1);
+          expect(cardData.numberOfInvoices).toBe(1);
+          // 500 のみ。他社 9999 が混入すると "$104.99" になる。
+          expect(cardData.totalPaidInvoices).toBe("$5.00");
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
     );
   });
 
@@ -24,9 +64,23 @@ describe("DashboardService", () => {
       Effect.gen(function* () {
         const service = yield* DashboardService;
         const revenue = yield* service.fetchRevenue();
-
         expect(revenue).toHaveLength(0);
-      }),
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect("自社の revenue のみ返す", ({ factory: f }) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() =>
+          f.revenue.create({ companyId: A, month: "2601", revenue: 1000 }),
+        );
+        yield* Effect.promise(() =>
+          f.revenue.create({ companyId: B, month: "2602", revenue: 2000 }),
+        );
+        const service = yield* DashboardService;
+        const revenue = yield* service.fetchRevenue();
+        expect(revenue).toHaveLength(1);
+        expect(revenue[0]?.revenue).toBe(1000);
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
     );
   });
 
@@ -35,9 +89,54 @@ describe("DashboardService", () => {
       Effect.gen(function* () {
         const service = yield* DashboardService;
         const invoices = yield* service.fetchLatestInvoices();
-
         expect(invoices).toHaveLength(0);
-      }),
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect("自社の最新 invoice のみ返す", ({ factory: f }) =>
+      Effect.gen(function* () {
+        const aCustomer = yield* Effect.promise(() =>
+          f.customer.create({ companyId: A, name: "Alice" }),
+        );
+        yield* Effect.promise(() =>
+          f.invoice.create({ companyId: A, customerId: aCustomer.id }),
+        );
+        const bCustomer = yield* Effect.promise(() =>
+          f.customer.create({ companyId: B, name: "Bob" }),
+        );
+        yield* Effect.promise(() =>
+          f.invoice.create({ companyId: B, customerId: bCustomer.id }),
+        );
+        const service = yield* DashboardService;
+        const invoices = yield* service.fetchLatestInvoices();
+        expect(invoices).toHaveLength(1);
+        expect(invoices[0]?.customer.name).toBe("Alice");
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect(
+      "他社 customer を参照する stray invoice は最新一覧に出ない (join scope)",
+      ({ factory: f }) =>
+        Effect.gen(function* () {
+          const aCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: A, name: "Alice" }),
+          );
+          yield* Effect.promise(() =>
+            f.invoice.create({ companyId: A, customerId: aCustomer.id }),
+          );
+          // companyId は A だが customer が B 社の stray invoice。
+          // join 先 customers の companyFilter で除外され顧客名が漏れない。
+          const bCustomer = yield* Effect.promise(() =>
+            f.customer.create({ companyId: B, name: "Bob" }),
+          );
+          yield* Effect.promise(() =>
+            f.invoice.create({ companyId: A, customerId: bCustomer.id }),
+          );
+          const service = yield* DashboardService;
+          const invoices = yield* service.fetchLatestInvoices();
+          expect(invoices).toHaveLength(1);
+          expect(invoices[0]?.customer.name).toBe("Alice");
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
     );
   });
 });

--- a/app/services/dashboard-service.ts
+++ b/app/services/dashboard-service.ts
@@ -1,8 +1,10 @@
 import * as PgDrizzle from "@effect/sql-drizzle/Pg";
-import { desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { Effect } from "effect";
 import { formatCurrency } from "@/app/lib/utils";
 import { customers, invoices, revenue } from "@/db/drizzle/schema";
+import { companyFilter } from "@/db/scoped";
+import { CompanyContext } from "./company-context";
 import { DashboardServiceError } from "./dashboard-errors";
 
 export type Revenue = {
@@ -27,13 +29,15 @@ export type CardData = {
   totalPendingInvoices: string;
 };
 
+// overview の全集計を CompanyContext の companyId で scope する。scope しないと
+// 売上チャート・カード・最新請求書が全社横断で漏れる。設計詳細: docs/adr/0002-company-data-scoping.md。
 export class DashboardService extends Effect.Service<DashboardService>()(
   "services/DashboardService",
   {
     effect: Effect.gen(function* () {
       const pgdrizzle = yield* PgDrizzle.PgDrizzle;
 
-      const fetchRevenueData = () =>
+      const fetchRevenueData = (companyId: string) =>
         Effect.tryPromise({
           try: () =>
             pgdrizzle
@@ -41,14 +45,15 @@ export class DashboardService extends Effect.Service<DashboardService>()(
                 month: revenue.month,
                 revenue: revenue.revenue,
               })
-              .from(revenue),
+              .from(revenue)
+              .where(companyFilter(revenue, companyId)),
           catch: (e) =>
             new DashboardServiceError({
               message: `fetchRevenue failed: ${e}`,
             }),
         });
 
-      const fetchLatestInvoicesData = () =>
+      const fetchLatestInvoicesData = (companyId: string) =>
         Effect.tryPromise({
           try: () =>
             pgdrizzle
@@ -60,7 +65,16 @@ export class DashboardService extends Effect.Service<DashboardService>()(
                 customerImageUrl: customers.imageUrl,
               })
               .from(invoices)
-              .innerJoin(customers, eq(invoices.customerId, customers.id))
+              // join 先 customers にも companyFilter を AND する。invoices を scope しても、
+              // stray な他社 customer を参照する行があると顧客名が漏れるため (innerJoin で除外)。
+              .innerJoin(
+                customers,
+                and(
+                  eq(invoices.customerId, customers.id),
+                  companyFilter(customers, companyId),
+                ),
+              )
+              .where(companyFilter(invoices, companyId))
               .orderBy(desc(invoices.date))
               .limit(5),
           catch: (e) =>
@@ -69,12 +83,13 @@ export class DashboardService extends Effect.Service<DashboardService>()(
             }),
         });
 
-      const fetchInvoiceCount = () =>
+      const fetchInvoiceCount = (companyId: string) =>
         Effect.tryPromise({
           try: async () => {
             const result = await pgdrizzle
               .select({ count: sql<number>`count(*)` })
-              .from(invoices);
+              .from(invoices)
+              .where(companyFilter(invoices, companyId));
             return Number(result[0].count);
           },
           catch: (e) =>
@@ -83,12 +98,13 @@ export class DashboardService extends Effect.Service<DashboardService>()(
             }),
         });
 
-      const fetchCustomerCount = () =>
+      const fetchCustomerCount = (companyId: string) =>
         Effect.tryPromise({
           try: async () => {
             const result = await pgdrizzle
               .select({ count: sql<number>`count(*)` })
-              .from(customers);
+              .from(customers)
+              .where(companyFilter(customers, companyId));
             return Number(result[0].count);
           },
           catch: (e) =>
@@ -97,15 +113,16 @@ export class DashboardService extends Effect.Service<DashboardService>()(
             }),
         });
 
-      const fetchInvoiceStatus = () =>
+      const fetchInvoiceStatus = (companyId: string) =>
         Effect.tryPromise({
           try: async () => {
             const result = await pgdrizzle
               .select({
-                paid: sql<number>`SUM(CASE WHEN status = 'paid' THEN amount ELSE 0 END)`,
-                pending: sql<number>`SUM(CASE WHEN status = 'pending' THEN amount ELSE 0 END)`,
+                paid: sql<number>`SUM(CASE WHEN ${invoices.status} = 'paid' THEN ${invoices.amount} ELSE 0 END)`,
+                pending: sql<number>`SUM(CASE WHEN ${invoices.status} = 'pending' THEN ${invoices.amount} ELSE 0 END)`,
               })
-              .from(invoices);
+              .from(invoices)
+              .where(companyFilter(invoices, companyId));
             return {
               paid: Number(result[0].paid) || 0,
               pending: Number(result[0].pending) || 0,
@@ -118,11 +135,16 @@ export class DashboardService extends Effect.Service<DashboardService>()(
         });
 
       return {
-        fetchRevenue: () => fetchRevenueData(),
+        fetchRevenue: () =>
+          Effect.gen(function* () {
+            const { companyId } = yield* CompanyContext;
+            return yield* fetchRevenueData(companyId);
+          }),
 
         fetchLatestInvoices: () =>
           Effect.gen(function* () {
-            const data = yield* fetchLatestInvoicesData();
+            const { companyId } = yield* CompanyContext;
+            const data = yield* fetchLatestInvoicesData(companyId);
             return data.map((invoice) => ({
               id: invoice.id,
               amount: formatCurrency(invoice.amount),
@@ -136,11 +158,12 @@ export class DashboardService extends Effect.Service<DashboardService>()(
 
         fetchCardData: () =>
           Effect.gen(function* () {
+            const { companyId } = yield* CompanyContext;
             const [invoiceCount, customerCount, invoiceStatus] =
               yield* Effect.all([
-                fetchInvoiceCount(),
-                fetchCustomerCount(),
-                fetchInvoiceStatus(),
+                fetchInvoiceCount(companyId),
+                fetchCustomerCount(companyId),
+                fetchInvoiceStatus(companyId),
               ]);
 
             return {

--- a/e2e/db/auth-schema.ts
+++ b/e2e/db/auth-schema.ts
@@ -18,6 +18,9 @@ export const user = pgTable(
     email: text("email").notNull().unique(),
     emailVerified: boolean("email_verified").default(false).notNull(),
     image: text("image"),
+    // session の companyId source (ADR-009)。dashboard は company 必須 (ADR-0002) のため
+    // e2e ユーザーにはここを set した上で sign-in する (verify 時に cookie へ焼き込まれる)。
+    lastUsedCompanyId: text("last_used_company_id"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -28,6 +31,26 @@ export const user = pgTable(
     ),
   ],
 );
+
+// dashboard アクセスに必要な company / membership (e2e helper 用、最小セット)。
+export const company = pgTable("company", {
+  id: text("id").primaryKey().notNull(),
+  name: text("name").notNull(),
+  orgCode: text("org_code").notNull(),
+  activationStatus: text("activation_status").default("ACTIVE").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const membership = pgTable("membership", {
+  id: text("id").primaryKey().notNull(),
+  userId: text("user_id").notNull(),
+  companyId: text("company_id").notNull(),
+  role: text("role").notNull(),
+  joinedAt: timestamp("joined_at").defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
 
 export const verification = pgTable(
   "verification",

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -85,8 +85,9 @@ test.describe("認証フロー", () => {
       const authedPage = await context.newPage();
       await authedPage.goto("/dashboard");
 
-      await expect(authedPage).toHaveURL(/\/dashboard/);
-      await expect(authedPage.locator("h1")).toContainText("Dashboard");
+      // 新規ユーザーは事業所未所属のため、dashboard ではなく事業所登録画面へ redirect される
+      // (ADR-0002 の company 必須フロー)。アカウント自体は作成済み。
+      await expect(authedPage).toHaveURL(/\/auth\/signup\/company/);
 
       await context.close();
     });

--- a/e2e/tests/utils/signIn.ts
+++ b/e2e/tests/utils/signIn.ts
@@ -1,8 +1,8 @@
 import { Browser, BrowserContext } from "@playwright/test";
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
 import { authDb } from "../../db/auth-client";
-import { user, verification } from "../../db/auth-schema";
+import { company, membership, user, verification } from "../../db/auth-schema";
 
 // taimei-auth (認証サーバー) 経由ログイン用の e2e signIn helper。
 // taimei (app.taimei-code.local:3001) と taimei-auth (auth.taimei-code.local:3100) は別オリジン。
@@ -20,13 +20,40 @@ const COOKIE_DOMAIN = ".taimei-code.local";
 
 export async function createTestUser(): Promise<string> {
   const uuid = crypto.randomUUID();
+  const email = `e2e-${uuid}@example.com`;
   await authDb.insert(user).values({
     id: uuid,
     name: "E2E Test User",
-    email: `e2e-${uuid}@example.com`,
+    email,
     emailVerified: false,
   });
-  return `e2e-${uuid}@example.com`;
+  // dashboard は事業所所属を要求する (ADR-0002)。sign-in (verify) の前に company /
+  // membership / last_used_company_id を用意し、companyId を session cookie へ焼き込ませる。
+  await provisionCompanyForUser(uuid);
+  return email;
+}
+
+// 指定 user に company + membership を作成し last_used_company_id を set する。
+// session の companyId source は user.last_used_company_id (ADR-009)。
+export async function provisionCompanyForUser(userId: string): Promise<string> {
+  const companyId = `cmp_e2e${userId.replace(/-/g, "").slice(0, 22)}`;
+  await authDb
+    .insert(company)
+    .values({
+      id: companyId,
+      name: "E2E Company",
+      orgCode: `e2e-${userId.slice(0, 8)}`,
+    })
+    .onConflictDoNothing();
+  await authDb
+    .insert(membership)
+    .values({ id: crypto.randomUUID(), userId, companyId, role: "OWNER" })
+    .onConflictDoNothing();
+  await authDb
+    .update(user)
+    .set({ lastUsedCompanyId: companyId })
+    .where(eq(user.id, userId));
+  return companyId;
 }
 
 // Server Action の非同期処理完了を待つため、トークンが見つかるまでポーリング (最大 20s)。


### PR DESCRIPTION
## やったこと

ダッシュボードの overview (売上チャート / カード集計 / 最新請求書) を session 由来の companyId で scope し、呼出側を `runScopedService` 経由にした。dashboard layout を `requireCompany` に切り替えた。集計金額の isolation テストを追加した。

## なぜやるのか

overview は全社横断で集計するため、scope しないと他社の売上・件数・請求書が自社のダッシュボードに漏れるため。

## 動作確認結果

`bun run test:db` 全 91 件緑。dev 環境で 2 社のデータを用意し、company A のダッシュボードがカード集計・最新請求書・売上チャートいずれも自社分のみを表示し、他社の金額・件数が混入しないことを確認した。

## 設計判断

集計の各ヘルパー (件数・合計・売上・最新) はそれぞれ独立して company で絞る。カードの支払済/未払合計や件数は集計クエリ単位で WHERE を付けないと他社分が加算されるため。

最新請求書は請求書側を絞るだけでなく、顧客名を取る結合の結合先 (顧客) にも company 条件を付ける。請求書を自社で絞っても、他社顧客を参照する不整合な行があるとその顧客名が漏れるため、結合段階で除外する。

layout の `requireCompany` は描画前の UX ガード。事業所未選択ならデータ取得前に登録ページへ redirect してチラつきを防ぐ。権威的な防御は各データ取得の `runScopedService` 自身が担い、layout を経由しない経路があっても穴にならない。

## やらなかったこと

タグの scope は Phase 2。NOT NULL 化と売上 unique の変更は別 PR。

## レビューしてほしい観点

集計クエリ (件数 / 合計 / 結合) のすべてに company の絞りが入っているか。

## Revert 手順

このブランチの revert で overview が無 scope に戻る。schema 変更を含まないため DB 影響なし。
