### PR TITLE
feat(db): company_id NOT NULL 化 + revenue unique を (company_id, month) に (ADR-0002 PR-5)

### DIFF
--- a/app/services/__tests__/db/company-scoping-migration.test.ts
+++ b/app/services/__tests__/db/company-scoping-migration.test.ts
@@ -1,0 +1,59 @@
+import { sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { testDb } from "./test-db";
+
+// migration の最終状態 (NOT NULL 化 + revenue unique 複合化 + index) を実 DB スキーマで検証する。
+// global-setup が drizzle-kit migrate で全 migration を適用済の test DB を対象にする。
+// 設計詳細: docs/adr/0002-company-data-scoping.md。
+describe("company_id scoping migration", () => {
+  it("customers/invoices/revenue の company_id が NOT NULL である", async () => {
+    const res = await testDb.execute(sql`
+      SELECT table_name, is_nullable
+      FROM information_schema.columns
+      WHERE table_name IN ('customers', 'invoices', 'revenue')
+        AND column_name = 'company_id'
+      ORDER BY table_name
+    `);
+    const rows = res.rows as { table_name: string; is_nullable: string }[];
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.is_nullable).toBe("NO");
+    }
+  });
+
+  it("revenue の unique は (company_id, month) のみで (month) 単独は残らない", async () => {
+    const res = await testDb.execute(sql`
+      SELECT indexname FROM pg_indexes WHERE tablename = 'revenue'
+    `);
+    const names = (res.rows as { indexname: string }[]).map((r) => r.indexname);
+    expect(names).toContain("revenue_company_month_key");
+    expect(names).not.toContain("revenue_month_key");
+  });
+
+  it("company_id index が customers/invoices/revenue に存在する", async () => {
+    const res = await testDb.execute(sql`
+      SELECT indexname FROM pg_indexes
+      WHERE indexname IN (
+        'customers_company_id_idx',
+        'invoices_company_id_idx',
+        'revenue_company_id_idx'
+      )
+    `);
+    expect(res.rows).toHaveLength(3);
+  });
+
+  it("company_id に NULL 行が残っていない (backfill 検証)", async () => {
+    const res = await testDb.execute(sql`
+      SELECT
+        (SELECT count(*) FROM customers WHERE company_id IS NULL) AS customers,
+        (SELECT count(*) FROM invoices WHERE company_id IS NULL) AS invoices,
+        (SELECT count(*) FROM revenue WHERE company_id IS NULL) AS revenue
+    `);
+    const row = (
+      res.rows as { customers: string; invoices: string; revenue: string }[]
+    )[0];
+    expect(Number(row.customers)).toBe(0);
+    expect(Number(row.invoices)).toBe(0);
+    expect(Number(row.revenue)).toBe(0);
+  });
+});

--- a/db/drizzle/schema.ts
+++ b/db/drizzle/schema.ts
@@ -20,9 +20,8 @@ export const customers = pgTable(
     email: varchar({ length: 255 }).notNull(),
     imageUrl: varchar("image_url", { length: 255 }).notNull(),
     // company_id は auth (taimei-auth) の company.id (cmp_<nanoid24>) への論理参照。
-    // cross-DB のため FK は張らない。nullable で追加し NOT NULL 化は別 migration (expand-contract)。
-    // 設計詳細: docs/adr/0002-company-data-scoping.md (D9)
-    companyId: varchar("company_id", { length: 32 }),
+    // cross-DB のため FK は張らない。設計詳細: docs/adr/0002-company-data-scoping.md
+    companyId: varchar("company_id", { length: 32 }).notNull(),
   },
   (table) => [index("customers_company_id_idx").on(table.companyId)],
 );
@@ -58,7 +57,7 @@ export const invoices = pgTable(
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
     // auth company.id への論理参照 (FK なし)。詳細は customers.companyId と docs/adr/0002 を参照。
-    companyId: varchar("company_id", { length: 32 }),
+    companyId: varchar("company_id", { length: 32 }).notNull(),
   },
   (table) => [
     foreignKey({
@@ -84,14 +83,11 @@ export const revenue = pgTable(
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
     // auth company.id への論理参照 (FK なし)。詳細は customers.companyId と docs/adr/0002 を参照。
-    // month 単独 unique は別 migration で (company_id, month) に変更する (社ごと同月行を許可)。
-    companyId: varchar("company_id", { length: 32 }),
+    companyId: varchar("company_id", { length: 32 }).notNull(),
   },
   (table) => [
-    uniqueIndex("revenue_month_key").using(
-      "btree",
-      table.month.asc().nullsLast().op("text_ops"),
-    ),
+    // unique は (company_id, month) 複合。社ごとに同じ月の行を持てるようにする。
+    uniqueIndex("revenue_company_month_key").on(table.companyId, table.month),
     index("revenue_company_id_idx").on(table.companyId),
   ],
 );

--- a/drizzle/0004_groovy_tyger_tiger.sql
+++ b/drizzle/0004_groovy_tyger_tiger.sql
@@ -1,0 +1,11 @@
+-- NOT NULL 化の前に straggler な NULL 行を placeholder で backfill する (forward-only・冪等)。
+-- ops の手動 backfill 漏れがあっても NOT NULL 化が失敗しない安全網。
+-- 設計詳細: docs/adr/0002-company-data-scoping.md (D9 / expand-contract の contract 段)。
+UPDATE "customers" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;--> statement-breakpoint
+UPDATE "invoices" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;--> statement-breakpoint
+UPDATE "revenue" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;--> statement-breakpoint
+DROP INDEX "revenue_month_key";--> statement-breakpoint
+ALTER TABLE "customers" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "invoices" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "revenue" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "revenue_company_month_key" ON "revenue" USING btree ("company_id","month");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,384 @@
+{
+  "id": "d31f4fb9-9143-4038-b380-76c69fca3670",
+  "prevId": "2a27fc1b-8c47-47e5-a085-b2eff4f62f4a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customers_company_id_idx": {
+          "name": "customers_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invoices_company_id_idx": {
+          "name": "invoices_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_customer_id_fkey": {
+          "name": "invoices_customer_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": ["customer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._invoicesTotags": {
+      "name": "_invoicesTotags",
+      "schema": "",
+      "columns": {
+        "A": {
+          "name": "A",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "B": {
+          "name": "B",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_invoicesTotags_B_index": {
+          "name": "_invoicesTotags_B_index",
+          "columns": [
+            {
+              "expression": "B",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_invoicesTotags_A_fkey": {
+          "name": "_invoicesTotags_A_fkey",
+          "tableFrom": "_invoicesTotags",
+          "tableTo": "invoices",
+          "columnsFrom": ["A"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "_invoicesTotags_B_fkey": {
+          "name": "_invoicesTotags_B_fkey",
+          "tableFrom": "_invoicesTotags",
+          "tableTo": "tags",
+          "columnsFrom": ["B"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "_invoicesTotags_AB_pkey": {
+          "name": "_invoicesTotags_AB_pkey",
+          "columns": ["A", "B"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revenue": {
+      "name": "revenue",
+      "schema": "",
+      "columns": {
+        "month": {
+          "name": "month",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revenue_company_month_key": {
+          "name": "revenue_company_month_key",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "revenue_company_id_idx": {
+          "name": "revenue_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags2": {
+      "name": "tags2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1779878912291,
       "tag": "0003_funny_exiles",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1779885588499,
+      "tag": "0004_groovy_tyger_tiger",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## やったこと

`customers` / `invoices` / `revenue` の `company_id` を NOT NULL 化し、`revenue` の unique を `(month)` 単独から `(company_id, month)` 複合に変更した。生成 migration の NOT NULL 化の前に冪等な backfill を前置した。最終状態を検証する migration テストを追加した。

## なぜやるのか

列追加 (nullable) の後、`company_id` を書くアプリのデプロイが済んだ段階で、欠損や重複を DB 制約として固定するため。売上は社ごとに同じ月の行を持つので unique を複合にする必要がある。

## 動作確認結果

test DB に migration 適用後、全 95 件緑。migration テストで NOT NULL・複合 unique・index の存在と NULL 行 0 件を確認した。

## 設計判断

NOT NULL 化の前に、NULL が残っていれば placeholder で埋める更新を同じ migration 内に置いた。列追加とアプリデプロイの後にこの制約を適用する運用だが、取りこぼした行があっても制約適用が失敗しないための安全網。条件付き更新なので複数回流しても影響しない。

売上の unique は古い `(month)` を drop してから `(company_id, month)` を作り直す。これにより別会社が同じ月の行を持てる。

## やらなかったこと

タグの scope は Phase 2。down migration は用意しない (forward-only。戻す場合は nullable に戻す migration を別途 push)。

## レビューしてほしい観点

NOT NULL 化の前に backfill が走る順序になっているか。デプロイ順序の前提 (列を書くアプリが先にデプロイ済)。

## Revert 手順

forward-only。戻す場合は `company_id` を nullable に戻し unique を `(month)` に戻す migration を別 PR で push する (この migration の単純 revert では本番に未適用の SQL を消すだけで、適用済みの制約は戻らない)。
