### PR TITLE
fix(db): 0004 の revenue unique drop を constraint/index 両構えにする (ADR-0002 PR-5 本番修正)

### DIFF
--- a/docs/adr/0002-company-data-scoping.md
+++ b/docs/adr/0002-company-data-scoping.md
@@ -337,6 +337,16 @@ Phase は手動 QA できる end-to-end 単位で分割 (ADR-009 流)。
 - **rollback**: NOT NULL / unique 変更は forward migration で「アプリだけ rollback」が効かない (新 schema 上で旧アプリが violation)。drizzle-kit に down が無いため revert 用 nullable 戻し SQL を `drizzle/manual/` に用意し、**「rollback は forward-only (戻し migration を別 push)」を運用方針に固定**。
 - **RLS 前倒しトリガー**: 「**最初の実顧客受入前**に RLS を defense-in-depth で入れる」を時系列トリガーに追加 (『pen-test 指摘後』= 漏れた後では遅い)。
 
+**D-4. migration の環境間スキーマ出自差 (PR-5 で実際に踏んだ本番障害)**: PR-5 (0004) の本番 migrate-deploy が `cannot drop index "revenue_month_key" because constraint "revenue_month_key" requires it` で失敗した。原因は **同名オブジェクトの内部種別が環境で食い違っていた**こと —
+- **本番**: `revenue_month_key` は UNIQUE **constraint** (旧ツール由来。drizzle 0000 は introspect で起こされたため、本番には drizzle 以前から constraint が存在し、0000 の `CREATE UNIQUE INDEX IF NOT EXISTS` は本番では既存ヒットで skip されていた)。
+- **test/dev**: 同名が drizzle 0000 由来の **index** (空 DB に 0000 を流すと `CREATE UNIQUE INDEX` で index として作られる)。
+- `DROP INDEX` は constraint を落とせない → 本番だけ失敗、空の test DB では再現せず。
+
+対策:
+- **両構え drop**: 種別が環境で異なりうる drop は `ALTER TABLE ... DROP CONSTRAINT IF EXISTS` + `DROP INDEX IF EXISTS` を併記する (constraint を落とせば裏付け index も消え、後段の `DROP INDEX IF EXISTS` は no-op で安全)。
+- **本番出自での dry-run を検証段に組み込む**: 「空の test DB で通る ≠ 本番で通る」。破壊的 DDL を含む migration は、本番スキーマのダンプ (構造のみ) or 本番への `BEGIN; \i <migration>; ROLLBACK;` dry-run で**適用前に**検証する。
+- **drizzle-kit migrate はトランザクション migration (実機確認済み)**: 1 migration ファイルを単一トランザクションで包み、途中失敗時は**前段の文 (backfill UPDATE 等) も含め全ロールバック・journal にも未記録**。よって失敗 migration は「部分適用」を残さず、**ファイルを修正して再 push すれば未適用とみなして atomically 再実行**される (journal 手動編集や手動 DDL 復旧は不要)。これが本 migration 群の forward-only 運用の安全性の根拠。
+
 ### Phase E+ (将来トリガー時)
 
 - RLS を defense-in-depth で追加 (Alternatives Considered のトリガー: 本番課金 / 実顧客企業 / pen-test 指摘)

--- a/drizzle/0004_groovy_tyger_tiger.sql
+++ b/drizzle/0004_groovy_tyger_tiger.sql
@@ -4,7 +4,12 @@
 UPDATE "customers" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;--> statement-breakpoint
 UPDATE "invoices" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;--> statement-breakpoint
 UPDATE "revenue" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;--> statement-breakpoint
-DROP INDEX "revenue_month_key";--> statement-breakpoint
+-- revenue_month_key は環境で実体が異なる (本番=旧ツール由来の UNIQUE constraint /
+-- test・dev=drizzle 0000 由来の index)。constraint は DROP INDEX で落とせないため両構えで落とす。
+-- constraint を落とせば裏付け index も消え、後段の DROP INDEX IF EXISTS は no-op になる。
+-- 設計詳細: docs/adr/0002-company-data-scoping.md (D-4)。
+ALTER TABLE "revenue" DROP CONSTRAINT IF EXISTS "revenue_month_key";--> statement-breakpoint
+DROP INDEX IF EXISTS "revenue_month_key";--> statement-breakpoint
 ALTER TABLE "customers" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "invoices" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "revenue" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint


### PR DESCRIPTION
## やったこと

PR #519 (0004 migration) の本番 migrate-deploy 失敗を修正する。`revenue` の旧 unique を落とす文を `DROP INDEX` から `DROP CONSTRAINT IF EXISTS` + `DROP INDEX IF EXISTS` の両構えに変更した。原因分析と恒久対策を ADR D-4 に追記した。

## なぜやるのか

本番の `revenue_month_key` は旧ツール由来の UNIQUE constraint で、`DROP INDEX` では落とせず本番 migrate-deploy が失敗していた。test/dev は drizzle 由来の index のため再現せず、環境間でオブジェクトの実体が食い違っていた。両構えにすればどちらの環境でも落ちる。

## 動作確認結果

本番出自を模した dry-run (`BEGIN; ... ROLLBACK;` で本番無変更) と、fresh DB への全 migration 適用 (index 環境) の双方で 0004 が最後まで成功することを確認。company_id 3 テーブルが NOT NULL 化され、revenue の unique が `(company_id, month)` のみになることを検証。`bun run test:db` 全 95 件緑。

## 設計判断

既存 migration ファイル (0004) を新規 migration を足さず直接修正した。drizzle-kit migrate は 1 migration を単一トランザクションで実行し、途中失敗時は前段の文も含め全ロールバック・journal にも未記録になる (実機確認済)。本番 journal に 0004 が記録されていない (= クリーンに失敗) ことを確認済みのため、ファイルを修正して再適用させると未適用とみなされ atomically に流れる。

constraint を先に落とせば裏付け index も同時に消えるため、後段の `DROP INDEX IF EXISTS` は no-op になる。順序はこの依存を踏まえている。

## やらなかったこと

本番 journal の旧 migration (id3) の hash と現リポジトリの不一致は、PR #511 が SQL ヘッダコメントのみを変更した結果で実行 DDL は不変・実害なしと確認したため、本 PR では触らない。

## レビューしてほしい観点

既存 migration ファイルを編集する判断の妥当性 (本番 journal に 0004 未記録という前提)。両構え drop の順序。

## Revert 手順

main マージ時に本番へ自動適用される。問題時は company_id を nullable に戻し unique を `(month)` に戻す forward migration を別 push する。
