### PR TITLE
chore(compose): taimei postgres の host ポートを 5433 に退避

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker compose up --build --watch
 - `taimei-auth/.env` に `AUTH_SECRET` 等が設定済 (詳細は taimei-auth リポの README 参照)
 - 以下の port が空いていること (占有時は `docker ps | grep <port>` で特定して `docker stop <container>` で解放):
   - 3001 (taimei application) / 3100 (auth-service)
-  - 5432 (taimei postgres) / 5434 (taimei test_db) / 5435 (auth-postgres) / 6380 (auth-redis)
+  - 5433 (taimei postgres) / 5434 (taimei test_db) / 5435 (auth-postgres) / 6380 (auth-redis)
 
 ### 停止順
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,10 @@ services:
         source: "./dump"
         target: "/dump"
     ports:
-      - "5432:5432"
+      # host 側は 5433 に退避。default の 5432 は他のローカル postgres スタックと衝突しやすいため
+      # 常時共存できるようズラす (port 割り当て一覧は README.md「前提」参照)。
+      # container 側 5432 は据え置き — application は service 名 postgres:5432 で繋ぐので無影響。
+      - "5433:5432"
     environment:
       - POSTGRES_DATABASE=postgres
       - POSTGRES_USER=postgres


### PR DESCRIPTION
## やったこと

ローカル開発の docker-compose で taimei postgres の host ポートを 5432 から 5433 に退避し、README のポート一覧を更新した。

## なぜやるのか

default の 5432 は他のローカル postgres スタックと衝突しやすく、共存できず起動を止め合うため。host ポートをズラして常時共存できるようにする。

## 動作確認結果

container 側は 5432 据え置きで、application は service 名 postgres:5432 で接続するため host ポート変更の影響を受けない。CI の unit-test は test_db (5434) のみ起動し 5432 を使わないため無影響。

## 設計判断

container 側ポートは変えず host 側のみ退避した。コンテナ間通信は service 名で解決するので、外向きの host ポートだけズラせば衝突を避けつつ接続経路は不変に保てる。

## やらなかったこと

test_db (5434) / auth-postgres (5435) / auth-redis (6380) のポートは衝突実績がないため変更しない。

## レビューしてほしい観点

特になし (ローカル構成のみの変更)。

## Revert 手順

このブランチの revert で host ポートが 5432 に戻る。ローカル構成のみで本番・DB データへの影響なし。
