### PR TITLE
feat(tag): tags/tags2 を company_id で scope する (ADR-0002 PR-6)

### DIFF
--- a/app/services/__tests__/db/company-scoping-migration.test.ts
+++ b/app/services/__tests__/db/company-scoping-migration.test.ts
@@ -6,16 +6,16 @@ import { testDb } from "./test-db";
 // global-setup が drizzle-kit migrate で全 migration を適用済の test DB を対象にする。
 // 設計詳細: docs/adr/0002-company-data-scoping.md。
 describe("company_id scoping migration", () => {
-  it("customers/invoices/revenue の company_id が NOT NULL である", async () => {
+  it("customers/invoices/revenue/tags/tags2 の company_id が NOT NULL である", async () => {
     const res = await testDb.execute(sql`
       SELECT table_name, is_nullable
       FROM information_schema.columns
-      WHERE table_name IN ('customers', 'invoices', 'revenue')
+      WHERE table_name IN ('customers', 'invoices', 'revenue', 'tags', 'tags2')
         AND column_name = 'company_id'
       ORDER BY table_name
     `);
     const rows = res.rows as { table_name: string; is_nullable: string }[];
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(5);
     for (const row of rows) {
       expect(row.is_nullable).toBe("NO");
     }
@@ -30,16 +30,18 @@ describe("company_id scoping migration", () => {
     expect(names).not.toContain("revenue_month_key");
   });
 
-  it("company_id index が customers/invoices/revenue に存在する", async () => {
+  it("company_id index が customers/invoices/revenue/tags/tags2 に存在する", async () => {
     const res = await testDb.execute(sql`
       SELECT indexname FROM pg_indexes
       WHERE indexname IN (
         'customers_company_id_idx',
         'invoices_company_id_idx',
-        'revenue_company_id_idx'
+        'revenue_company_id_idx',
+        'tags_company_id_idx',
+        'tags2_company_id_idx'
       )
     `);
-    expect(res.rows).toHaveLength(3);
+    expect(res.rows).toHaveLength(5);
   });
 
   it("company_id に NULL 行が残っていない (backfill 検証)", async () => {
@@ -47,13 +49,23 @@ describe("company_id scoping migration", () => {
       SELECT
         (SELECT count(*) FROM customers WHERE company_id IS NULL) AS customers,
         (SELECT count(*) FROM invoices WHERE company_id IS NULL) AS invoices,
-        (SELECT count(*) FROM revenue WHERE company_id IS NULL) AS revenue
+        (SELECT count(*) FROM revenue WHERE company_id IS NULL) AS revenue,
+        (SELECT count(*) FROM tags WHERE company_id IS NULL) AS tags,
+        (SELECT count(*) FROM tags2 WHERE company_id IS NULL) AS tags2
     `);
     const row = (
-      res.rows as { customers: string; invoices: string; revenue: string }[]
+      res.rows as {
+        customers: string;
+        invoices: string;
+        revenue: string;
+        tags: string;
+        tags2: string;
+      }[]
     )[0];
     expect(Number(row.customers)).toBe(0);
     expect(Number(row.invoices)).toBe(0);
     expect(Number(row.revenue)).toBe(0);
+    expect(Number(row.tags)).toBe(0);
+    expect(Number(row.tags2)).toBe(0);
   });
 });

--- a/app/services/__tests__/db/effect-test-helpers.ts
+++ b/app/services/__tests__/db/effect-test-helpers.ts
@@ -7,6 +7,7 @@ import { AuthClient } from "../../auth-client-service";
 import { CustomerService } from "../../customer-service";
 import { DashboardService } from "../../dashboard-service";
 import { InvoiceService } from "../../invoice-service";
+import { Tag2Service } from "../../tag2-service";
 import { UserService } from "../../user-service";
 import { factory } from "../factories";
 import { type TestDb, withRollback } from "./test-db";
@@ -23,6 +24,7 @@ type ServiceLayer =
   | CustomerService
   | InvoiceService
   | DashboardService
+  | Tag2Service
   | AccountValidationService;
 
 const createTestServiceLayer = (tx: TestDb) => {
@@ -48,6 +50,7 @@ const createTestServiceLayer = (tx: TestDb) => {
     CustomerService.Default,
     InvoiceService.Default,
     DashboardService.Default,
+    Tag2Service.Default,
     AccountValidationService.Default.pipe(Layer.provide(UserServiceLayer)),
   ).pipe(Layer.provide(TestPgDrizzleLayer));
 };

--- a/app/services/__tests__/factories/index.ts
+++ b/app/services/__tests__/factories/index.ts
@@ -1,43 +1,8 @@
 import { composeFactory, defineFactory } from "@praha/drizzle-factory";
-import {
-  boolean,
-  pgTable,
-  text,
-  timestamp,
-  uniqueIndex,
-} from "drizzle-orm/pg-core";
-import * as appSchema from "@/db/drizzle/schema";
+import { factorySchema } from "./test-schema";
 
-// user テーブルは auth-service DB に移動済みだが、テストでは taimei DB に
-// 残存する user テーブルに直接書き込む（テスト用の暫定措置）
-const user = pgTable(
-  "user",
-  {
-    id: text("id").primaryKey().notNull(),
-    name: text("name").notNull(),
-    email: text("email").notNull().unique(),
-    emailVerified: boolean("email_verified").default(false).notNull(),
-    image: text("image"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
-      .defaultNow()
-      .$onUpdate(() => new Date())
-      .notNull(),
-  },
-  (table) => [
-    uniqueIndex("user_email_key").using(
-      "btree",
-      table.email.asc().nullsLast().op("text_ops"),
-    ),
-  ],
-);
-
-// test-db.ts からも参照するため export
-export const testTableSchema = { user };
-
-// composeFactory は全 factory が同一 Schema 型を共有する必要があるため、
-// アプリスキーマ (customers/invoices/revenue 等) と test 用 user を統合した schema を使う。
-const factorySchema = { ...appSchema, user };
+// test-db.ts が既存の import パス (../factories) を維持できるよう re-export する。
+export { testTableSchema } from "./test-schema";
 
 // company_id は sequence ユニークな default にする。設計意図: docs/adr/0002 のテスト戦略。
 // 固定 default だと isolation テストで override 忘れ時に 2 社が同一 company になり誤 pass するが、
@@ -109,11 +74,24 @@ export const revenueFactory = defineFactory({
   schema: factorySchema,
   table: "revenue",
   resolver: ({ sequence }) => ({
-    // month 単独 unique (PR-5 で (company_id, month) 化) のため sequence でユニークにする。
+    // revenue unique は (company_id, month) 複合 (PR-5 で month 単独から変更)。同一 company で
+    // 複数行を作るテストでも (company_id, month) 衝突しないよう month を sequence でユニーク化する。
     month: String(sequence).padStart(4, "0"),
     revenue: 10000 + sequence,
     createdAt: "2026-01-01 00:00:00",
     updatedAt: "2026-01-01 00:00:00",
+    companyId: defaultCompanyId(sequence),
+  }),
+});
+
+export const tag2Factory = defineFactory({
+  schema: factorySchema,
+  table: "tags2",
+  resolver: ({ sequence }) => ({
+    id: crypto.randomUUID(),
+    name: `Tag ${sequence}`,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
     companyId: defaultCompanyId(sequence),
   }),
 });
@@ -123,4 +101,5 @@ export const factory = composeFactory({
   customer: customerFactory,
   invoice: invoiceFactory,
   revenue: revenueFactory,
+  tag2: tag2Factory,
 });

--- a/app/services/__tests__/factories/test-schema.ts
+++ b/app/services/__tests__/factories/test-schema.ts
@@ -1,0 +1,39 @@
+import {
+  boolean,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import * as appSchema from "@/db/drizzle/schema";
+
+// user テーブルは auth-service DB に移動済みだが、テストでは taimei DB に
+// 残存する user テーブルに直接書き込む（テスト用の暫定措置）
+const user = pgTable(
+  "user",
+  {
+    id: text("id").primaryKey().notNull(),
+    name: text("name").notNull(),
+    email: text("email").notNull().unique(),
+    emailVerified: boolean("email_verified").default(false).notNull(),
+    image: text("image"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("user_email_key").using(
+      "btree",
+      table.email.asc().nullsLast().op("text_ops"),
+    ),
+  ],
+);
+
+// test-db.ts からも参照するため export
+export const testTableSchema = { user };
+
+// composeFactory は全 factory が同一 Schema 型を共有する必要があるため、
+// アプリスキーマ (customers/invoices/revenue 等) と test 用 user を統合した schema を使う。
+export const factorySchema = { ...appSchema, user };

--- a/app/services/__tests__/tag2-service.test.ts
+++ b/app/services/__tests__/tag2-service.test.ts
@@ -1,0 +1,76 @@
+import { expect } from "@effect/vitest";
+import { Effect, Either } from "effect";
+import { describe } from "vitest";
+import { CompanyContext } from "../company-context";
+import { Tag2Service } from "../tag2-service";
+import { dbEffect } from "./db/effect-test-helpers";
+
+const A = "cmp_aaa";
+const B = "cmp_bbb";
+
+describe("Tag2Service", () => {
+  describe("findAll (空)", () => {
+    dbEffect("正常系: タグが無い場合は空配列を返す", () =>
+      Effect.gen(function* () {
+        const service = yield* Tag2Service;
+        const tags = yield* service.findAll();
+        expect(tags).toHaveLength(0);
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+  });
+
+  describe("scoping (社ごとのタグ辞書分離)", () => {
+    dbEffect("findAll は自社のタグのみ返す", ({ factory: f }) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() =>
+          f.tag2.create({ companyId: A, name: "A社タグ" }),
+        );
+        yield* Effect.promise(() =>
+          f.tag2.create({ companyId: B, name: "B社タグ" }),
+        );
+        const service = yield* Tag2Service;
+        const tags = yield* service.findAll();
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.name).toBe("A社タグ");
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect(
+      "find: A context で B のタグは Tag2NotFound (404)",
+      ({ factory: f }) =>
+        Effect.gen(function* () {
+          const b = yield* Effect.promise(() =>
+            f.tag2.create({ companyId: B }),
+          );
+          const service = yield* Tag2Service;
+          const res = yield* Effect.either(service.find(b.id));
+          expect(Either.isLeft(res)).toBe(true);
+          if (Either.isLeft(res)) expect(res.left._tag).toBe("Tag2NotFound");
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+
+    dbEffect("find: A context で自社のタグは取得できる", ({ factory: f }) =>
+      Effect.gen(function* () {
+        const a = yield* Effect.promise(() =>
+          f.tag2.create({ companyId: A, name: "自社タグ" }),
+        );
+        const service = yield* Tag2Service;
+        const tag = yield* service.find(a.id);
+        expect(tag.name).toBe("自社タグ");
+      }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+  });
+
+  describe("id 検証", () => {
+    dbEffect(
+      "find: 不正な UUID は Tag2ParseError (DB cast エラー前に弾く)",
+      () =>
+        Effect.gen(function* () {
+          const service = yield* Tag2Service;
+          const res = yield* Effect.either(service.find("not-a-uuid"));
+          expect(Either.isLeft(res)).toBe(true);
+          if (Either.isLeft(res)) expect(res.left._tag).toBe("Tag2ParseError");
+        }).pipe(Effect.provide(CompanyContext.layer({ companyId: A }))),
+    );
+  });
+});

--- a/app/services/tag2-service.ts
+++ b/app/services/tag2-service.ts
@@ -1,8 +1,10 @@
 import * as PgDrizzle from "@effect/sql-drizzle/Pg";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { Effect, Schema } from "effect";
 import { Tag2Id } from "@/app/schema/tag2";
 import { tags2 } from "@/db/drizzle/schema";
+import { companyFilter } from "@/db/scoped";
+import { CompanyContext } from "./company-context";
 import { Tag2NotFound, Tag2ParseError, Tag2ServiceError } from "./tag2-errors";
 
 export class Tag2Service extends Effect.Service<Tag2Service>()(
@@ -11,6 +13,8 @@ export class Tag2Service extends Effect.Service<Tag2Service>()(
     effect: Effect.gen(function* () {
       const pgdrizzle = yield* PgDrizzle.PgDrizzle;
 
+      // id を DB へ渡す前に UUID 形式を検証する。tags2.id は uuid 列のため不正文字列は
+      // PostgreSQL の cast エラー (500 相当) になる → 事前検証で Tag2ParseError として弾く。
       const validateTag2Id = (id: string) =>
         Effect.gen(function* () {
           yield* Schema.decode(Tag2Id)(id).pipe(
@@ -24,22 +28,32 @@ export class Tag2Service extends Effect.Service<Tag2Service>()(
           );
         });
 
+      // 社ごとのラベル辞書として scope する。設計詳細: docs/adr/0002-company-data-scoping.md。
       const findAll = () =>
-        Effect.tryPromise({
-          try: () => pgdrizzle.select().from(tags2),
-          catch: (e) =>
-            new Tag2ServiceError({ message: `findAll failed: ${e}` }),
+        Effect.gen(function* () {
+          const { companyId } = yield* CompanyContext;
+          return yield* Effect.tryPromise({
+            try: () =>
+              pgdrizzle
+                .select()
+                .from(tags2)
+                .where(companyFilter(tags2, companyId)),
+            catch: (e) =>
+              new Tag2ServiceError({ message: `findAll failed: ${e}` }),
+          });
         });
 
       const find = (id: string) =>
         Effect.gen(function* () {
           yield* validateTag2Id(id);
+          const { companyId } = yield* CompanyContext;
+          // 他社 id は WHERE で除外 → 空 → Tag2NotFound (404 = 存在自体を隠蔽)。
           const tag = yield* Effect.tryPromise({
             try: () =>
               pgdrizzle
                 .select()
                 .from(tags2)
-                .where(eq(tags2.id, id))
+                .where(and(eq(tags2.id, id), companyFilter(tags2, companyId)))
                 .then((res) => res.at(0)),
             catch: (e) =>
               new Tag2ServiceError({ message: `find failed: ${e}` }),

--- a/db/drizzle/schema.ts
+++ b/db/drizzle/schema.ts
@@ -26,21 +26,33 @@ export const customers = pgTable(
   (table) => [index("customers_company_id_idx").on(table.companyId)],
 );
 
-export const tags2 = pgTable("tags2", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  name: varchar({ length: 255 }).notNull(),
-  createdAt: timestamp("created_at", { precision: 6, mode: "date" })
-    .default(sql`CURRENT_TIMESTAMP`)
-    .notNull(),
-  updatedAt: timestamp("updated_at", { precision: 6, mode: "date" })
-    .default(sql`CURRENT_TIMESTAMP`)
-    .notNull(),
-});
+export const tags2 = pgTable(
+  "tags2",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    name: varchar({ length: 255 }).notNull(),
+    createdAt: timestamp("created_at", { precision: 6, mode: "date" })
+      .default(sql`CURRENT_TIMESTAMP`)
+      .notNull(),
+    updatedAt: timestamp("updated_at", { precision: 6, mode: "date" })
+      .default(sql`CURRENT_TIMESTAMP`)
+      .notNull(),
+    // auth company.id への論理参照 (FK なし)。詳細は customers.companyId と docs/adr/0002 を参照。
+    companyId: varchar("company_id", { length: 32 }).notNull(),
+  },
+  (table) => [index("tags2_company_id_idx").on(table.companyId)],
+);
 
-export const tags = pgTable("tags", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  name: varchar({ length: 255 }).notNull(),
-});
+export const tags = pgTable(
+  "tags",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    name: varchar({ length: 255 }).notNull(),
+    // auth company.id への論理参照 (FK なし)。詳細は customers.companyId と docs/adr/0002 を参照。
+    companyId: varchar("company_id", { length: 32 }).notNull(),
+  },
+  (table) => [index("tags_company_id_idx").on(table.companyId)],
+);
 
 export const invoices = pgTable(
   "invoices",

--- a/drizzle/0005_fair_thunderbird.sql
+++ b/drizzle/0005_fair_thunderbird.sql
@@ -1,0 +1,13 @@
+-- tags / tags2 を社ごとのラベル辞書として scope する。設計詳細: docs/adr/0002-company-data-scoping.md。
+-- ADD COLUMN ... NOT NULL を直接実行すると本番の既存行が制約違反で失敗するため、
+-- nullable 追加 → 冪等 backfill (placeholder) → NOT NULL 化 の順に展開する (D9 / PR-5 D-4 の踏襲)。
+-- tags は書き込みアプリ経路が存在しない (Tag2Service は read のみ) ため、nullable 期間に
+-- company_id なし INSERT が走る競合は起きず、expand/contract を別 PR に分ける必要はない。
+ALTER TABLE "tags" ADD COLUMN "company_id" varchar(32);--> statement-breakpoint
+ALTER TABLE "tags2" ADD COLUMN "company_id" varchar(32);--> statement-breakpoint
+UPDATE "tags" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;--> statement-breakpoint
+UPDATE "tags2" SET "company_id" = 'cmp_backfill_placeholder' WHERE "company_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "tags" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "tags2" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+CREATE INDEX "tags_company_id_idx" ON "tags" USING btree ("company_id");--> statement-breakpoint
+CREATE INDEX "tags2_company_id_idx" ON "tags2" USING btree ("company_id");

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,428 @@
+{
+  "id": "733c0836-e6df-4bf7-954d-5183e080f84b",
+  "prevId": "d31f4fb9-9143-4038-b380-76c69fca3670",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customers_company_id_idx": {
+          "name": "customers_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invoices_company_id_idx": {
+          "name": "invoices_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_customer_id_fkey": {
+          "name": "invoices_customer_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": ["customer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._invoicesTotags": {
+      "name": "_invoicesTotags",
+      "schema": "",
+      "columns": {
+        "A": {
+          "name": "A",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "B": {
+          "name": "B",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_invoicesTotags_B_index": {
+          "name": "_invoicesTotags_B_index",
+          "columns": [
+            {
+              "expression": "B",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_invoicesTotags_A_fkey": {
+          "name": "_invoicesTotags_A_fkey",
+          "tableFrom": "_invoicesTotags",
+          "tableTo": "invoices",
+          "columnsFrom": ["A"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "_invoicesTotags_B_fkey": {
+          "name": "_invoicesTotags_B_fkey",
+          "tableFrom": "_invoicesTotags",
+          "tableTo": "tags",
+          "columnsFrom": ["B"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "_invoicesTotags_AB_pkey": {
+          "name": "_invoicesTotags_AB_pkey",
+          "columns": ["A", "B"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revenue": {
+      "name": "revenue",
+      "schema": "",
+      "columns": {
+        "month": {
+          "name": "month",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revenue_company_month_key": {
+          "name": "revenue_company_month_key",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "revenue_company_id_idx": {
+          "name": "revenue_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_company_id_idx": {
+          "name": "tags_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags2": {
+      "name": "tags2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags2_company_id_idx": {
+          "name": "tags2_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1779885588499,
       "tag": "0004_groovy_tyger_tiger",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1780205789903,
+      "tag": "0005_fair_thunderbird",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

ADR-0002 (company data scoping) の Phase 2。`tags` / `tags2` を `company_id` で scope し、社ごとのタグ辞書を分離する。これにより customers/invoices/revenue で確立した company scoping を全テーブルへ展開し、ADR-0002 の全 PR (PR-0〜PR-6) が完了する。

設計詳細: `docs/adr/0002-company-data-scoping.md`

## 変更内容

### スキーマ / マイグレーション
- `tags` / `tags2` に `company_id` (`varchar(32)` NOT NULL) + index を追加 (auth `company.id` への論理参照、FK なし)
- migration `0005`: 既存行の制約違反を避けるため **nullable 追加 → 冪等 backfill → NOT NULL 化 → index** の expand-contract 順で展開

### サービス (`Tag2Service`)
- `findAll` / `find` を `companyFilter(tags2, companyId)` で scope
- 他社 `id` は WHERE で除外 → 空 → `Tag2NotFound` (404) で**存在自体を隠蔽** (IDOR 防御)
- `find` は `id` を DB へ渡す前に UUID 形式を検証し、不正値を `Tag2ParseError` で弾く (uuid 列への cast エラー = 500 を回避)

### テスト
- cross-company isolation テスト (findAll 空 / 自社のみ / 他社 id → `Tag2NotFound` / 自社 id 取得)
- 不正 UUID → `Tag2ParseError` テスト
- migration test を **5 テーブル** (customers/invoices/revenue + tags/tags2) の NOT NULL / index / backfill 検証に拡張
- test 用 DB スキーマを `test-schema.ts` に分離し factory 定義ファイルの責務を単一化

## 動作確認

- `bun tsc --noEmit` ✅
- `bun run lint` (biome + eslint) ✅
- `bun run test:db` ✅ 100 passed / 20 files

## 本番影響 ⚠️

merge により `drizzle-migrate-deploy` が発火し、**本番 (Neon) に `0005` が即適用**される (不可逆)。`tags` / `tags2` に `company_id` NOT NULL + index が追加され、既存行は backfill placeholder で埋まる。

## レビュー観点

- `Tag2Service.findAll` / `find` が他社データを確実に除外しているか (IDOR)
- `0005` の expand-contract 順が本番既存行で失敗しないか
- migration test の期待値 (`toHaveLength(5)`) が schema の実態と一致するか
