### PR TITLE
docs(adr): ADR-0002 を Accepted (実装完了) に更新

### DIFF
--- a/docs/adr/0002-company-data-scoping.md
+++ b/docs/adr/0002-company-data-scoping.md
@@ -1,6 +1,7 @@
 # ADR-0002: taimei 本体ドメインデータの company_id scoping
 
-- **Status**: Proposed
+- **Status**: Accepted
+- **実装**: 完了 (2026-05-31)。PR-0〜PR-6 を全 merge ([#514](https://github.com/YasuakiOmokawa/taimei/pull/514)〜[#522](https://github.com/YasuakiOmokawa/taimei/pull/522))。本番 (Neon) migrate-deploy 全 success、`tags` / `tags2` = NOT NULL + index + NULL 行 0 を psql 確認済。各 PR の内訳は plans/taimei `README.md`「直近の次タスク」を参照
 - **Date**: 2026-05-26
 - **References**: taimei-auth 事業所概念 ADR ([#55](https://github.com/taimei-code/taimei-auth/pull/55)〜[#63](https://github.com/taimei-code/taimei-auth/pull/63)、設計ログは plans/taimei `ADR-009`)。本 ADR 内の `ADR-009 §...` 参照はこの事業所概念 ADR を指す
 


### PR DESCRIPTION
## 概要

company data scoping (PR-0〜PR-6, #514〜#522) の merge + 本番 migrate-deploy success により実装が完了したため、`docs/adr/0002-company-data-scoping.md` の Status を **Proposed → Accepted** に更新し、実装完了 (PR 範囲 / 本番確認結果) をヘッダーに記録する。

plans/taimei `README.md` 側の Decision Log も同日更新済 (詳細な PR 内訳はそちらを SSOT とする)。

## 変更
- `docs/adr/0002-company-data-scoping.md`: Status `Proposed` → `Accepted` + `実装` 行追加 (docs のみ、コード変更なし)