### PR TITLE
fix(config): AUTH_SERVICE_URL を .env.production に明示

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,8 @@
 # Do not write security configuration data in this file!
 PROTOCOL="https://"
 NEXT_PUBLIC_APP_URL=https://app.taimei-code.com
+# auth-client SDK の RPC 接続先 (lib/auth/config.ts)。未設定だと http://localhost:3100 に fallback し
+# 本番でセッション検証 RPC が到達不能 → after-signin が signin_failed になるため repo にも明示 (secret ではない)
+AUTH_SERVICE_URL=https://auth.taimei-code.com
 AUTH_FROM_EMAIL_WELCOME=onboarding@taimei-code.com
 AUTH_FROM_EMAIL_MAGIC_LINK=notification@taimei-code.com


### PR DESCRIPTION
## 背景

本番で新規登録後のログインが `/auth/error?reason=signin_failed` で全断していた。

実機調査の結果:
- magic-link verify は成功 (session cookie 発行、app/auth/after-signin へ 302)
- after-signin の `getSession()` が null → signin_failed
- tail 上、after-signin 後に auth への verifySession RPC が一切届いていない

原因は consumer の `lib/auth/config.ts`:

```ts
const authServiceUrl = process.env.AUTH_SERVICE_URL || "http://localhost:3100";
baseUrl: `${authServiceUrl}/rpc`
```

Vercel Production に `AUTH_SERVICE_URL` が未注入だったため `http://localhost:3100/rpc` に
fallback し、SDK のセッション検証 RPC が Vercel から到達不能 → `getSession()` null →
after-signin が signin_failed へ。

## 対応

- Vercel Production に `AUTH_SERVICE_URL=https://auth.taimei-code.com` を追加済 (runtime 修正)
- 本 PR: repo の `.env.production` にも明示し、env 欠落時の silent localhost fallback を
  構造的に防ぐ (config.ts の FIXME が懸念していた点)

`AUTH_SERVICE_KEY` は secret のため従来どおり Vercel env のみ (repo には置かない)。

## 検証 (本番)

Vercel env 追加 + redeploy 後、既存セッションで after-signin → getSession 成立 →
新規ユーザーは /auth/signup/company → 事業所作成 → /dashboard 到達を実機確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)